### PR TITLE
Fix file saving and use file save dialog in Tauri app

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,145 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::process::Command;
+use tauri::Manager;
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+#[tauri::command]
+fn save_export_file(app: tauri::AppHandle, filename: String, content: String) -> Result<Option<String>, String> {
+    let safe_filename = sanitize_filename(&filename);
+    let export_path = match select_export_path(&app, &safe_filename)? {
+        Some(path) => path,
+        None => return Ok(None),
+    };
+
+    if let Some(parent_dir) = export_path.parent() {
+        fs::create_dir_all(parent_dir)
+            .map_err(|error| format!("Failed to create export directory: {error}"))?;
+    }
+
+    fs::write(&export_path, content).map_err(|error| format!("Failed to write export file: {error}"))?;
+
+    Ok(Some(export_path.to_string_lossy().into_owned()))
+}
+
+fn select_export_path(app: &tauri::AppHandle, filename: &str) -> Result<Option<PathBuf>, String> {
+    let export_dir = app
+        .path()
+        .download_dir()
+        .or_else(|_| app.path().document_dir())
+        .map_err(|_| String::from("Unable to resolve a writable export directory"))?;
+
+    fs::create_dir_all(&export_dir)
+        .map_err(|error| format!("Failed to create export directory: {error}"))?;
+
+    #[cfg(target_os = "macos")]
+    {
+        return choose_export_path_macos(filename, &export_dir);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let export_path = next_available_path(&export_dir, filename);
+        Ok(Some(export_path))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn choose_export_path_macos(filename: &str, export_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let output = Command::new("osascript")
+        .env("EXPORT_DEFAULT_NAME", filename)
+        .env("EXPORT_DEFAULT_DIR", export_dir.to_string_lossy().to_string())
+        .arg("-e")
+        .arg("set defaultName to system attribute \"EXPORT_DEFAULT_NAME\"")
+        .arg("-e")
+        .arg("set defaultDir to system attribute \"EXPORT_DEFAULT_DIR\"")
+        .arg("-e")
+        .arg("set targetFile to choose file name with prompt \"Save Export As\" default location (POSIX file defaultDir) default name defaultName")
+        .arg("-e")
+        .arg("POSIX path of targetFile")
+        .output()
+        .map_err(|error| format!("Failed to open save dialog: {error}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("User canceled") || stderr.contains("(-128)") {
+            return Ok(None);
+        }
+
+        return Err(format!("Save dialog failed: {}", stderr.trim()));
+    }
+
+    let selected_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if selected_path.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(PathBuf::from(selected_path)))
+}
+
+fn sanitize_filename(filename: &str) -> String {
+    let cleaned: String = filename
+        .trim()
+        .chars()
+        .map(|character| match character {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect();
+
+    let cleaned = cleaned
+        .trim_matches(|character: char| character == ' ' || character == '.')
+        .to_string();
+
+    if cleaned.is_empty() {
+        String::from("export.txt")
+    } else {
+        cleaned
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn next_available_path(directory: &Path, filename: &str) -> PathBuf {
+    let initial_path = directory.join(filename);
+    if !initial_path.exists() {
+        return initial_path;
+    }
+
+    let path = Path::new(filename);
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("export");
+    let extension = path.extension().and_then(|value| value.to_str()).unwrap_or("");
+
+    for index in 1.. {
+        let candidate_name = if extension.is_empty() {
+            format!("{stem} ({index})")
+        } else {
+            format!("{stem} ({index}).{extension}")
+        };
+        let candidate_path = directory.join(candidate_name);
+        if !candidate_path.exists() {
+            return candidate_path;
+        }
+    }
+
+    unreachable!()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![greet, save_export_file])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/components/ui/DownloadMenu.tsx
+++ b/src/components/ui/DownloadMenu.tsx
@@ -31,11 +31,17 @@ export function DownloadMenu({
     const handleDownload = async (format: 'html' | 'text', e: React.MouseEvent) => {
         e.stopPropagation();
         try {
+            let isSaved = false;
             if (type === 'story') {
-                await downloadStory(id, format);
+                isSaved = await downloadStory(id, format);
             } else {
-                await downloadChapter(id, format);
+                isSaved = await downloadChapter(id, format);
             }
+
+            if (!isSaved) {
+                return;
+            }
+
             toast.success(`${type === 'story' ? 'Story' : 'Chapter'} downloaded as ${format.toUpperCase()}`, {
                 position: "bottom-center",
                 autoClose: 2000,

--- a/src/features/lorebook/pages/LorebookPage.tsx
+++ b/src/features/lorebook/pages/LorebookPage.tsx
@@ -42,11 +42,13 @@ export default function LorebookPage() {
     }, {} as Record<string, number>);
 
     // Handle export functionality
-    const handleExport = () => {
+    const handleExport = async () => {
         if (storyId) {
             try {
-                exportEntries(storyId);
-                toast.success("Lorebook entries exported successfully");
+                const isSaved = await exportEntries(storyId);
+                if (isSaved) {
+                    toast.success("Lorebook entries exported successfully");
+                }
             } catch (error) {
                 console.error("Export failed:", error);
                 toast.error("Failed to export lorebook entries");

--- a/src/features/lorebook/stores/useLorebookStore.ts
+++ b/src/features/lorebook/stores/useLorebookStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { db } from '@/services/database';
 import type { LorebookEntry } from '@/types/story';
+import { saveTextAsFile } from '@/utils/fileDownload';
 
 interface LorebookState {
     entries: LorebookEntry[];
@@ -45,7 +46,7 @@ interface LorebookState {
     getEntriesByCustomField: (field: string, value: unknown) => LorebookEntry[];
 
     // Export/Import functions
-    exportEntries: (storyId: string) => void;
+    exportEntries: (storyId: string) => Promise<boolean>;
     importEntries: (jsonData: string, targetStoryId: string) => Promise<void>;
 }
 
@@ -320,7 +321,7 @@ export const useLorebookStore = create<LorebookState>((set, get) => ({
     },
 
     // Export lorebook entries
-    exportEntries: (storyId: string) => {
+    exportEntries: async (storyId: string) => {
         const { entries } = get();
         const storyEntries = entries.filter(entry => entry.storyId === storyId);
 
@@ -332,13 +333,8 @@ export const useLorebookStore = create<LorebookState>((set, get) => ({
         }, null, 2);
 
         // Create and trigger download
-        const dataUri = `data:application/json;charset=utf-8,${encodeURIComponent(dataStr)}`;
         const exportName = `lorebook-export-${new Date().toISOString().slice(0, 10)}.json`;
-
-        const linkElement = document.createElement('a');
-        linkElement.setAttribute('href', dataUri);
-        linkElement.setAttribute('download', exportName);
-        linkElement.click();
+        return await saveTextAsFile(dataStr, exportName, "application/json");
     },
 
     // Import lorebook entries

--- a/src/features/prompts/components/PromptsManager.tsx
+++ b/src/features/prompts/components/PromptsManager.tsx
@@ -93,8 +93,10 @@ export function PromptsManager() {
                             size="icon"
                             onClick={async () => {
                                 try {
-                                    await exportPrompts();
-                                    toast.success('Prompts exported');
+                                    const isSaved = await exportPrompts();
+                                    if (isSaved) {
+                                        toast.success('Prompts exported');
+                                    }
                                 } catch (error) {
                                     console.error('Export failed', error);
                                     toast.error('Failed to export prompts');

--- a/src/features/prompts/store/promptStore.ts
+++ b/src/features/prompts/store/promptStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { db } from '@/services/database';
 import type { Prompt, PromptMessage } from '@/types/story';
+import { saveTextAsFile } from '@/utils/fileDownload';
 
 interface PromptStore {
     prompts: Prompt[];
@@ -15,7 +16,7 @@ interface PromptStore {
     clonePrompt: (id: string) => Promise<void>;
 
     // Export/Import
-    exportPrompts: () => Promise<void>;
+    exportPrompts: () => Promise<boolean>;
     importPrompts: (jsonData: string) => Promise<void>;
 
     // Helpers
@@ -171,13 +172,8 @@ export const usePromptStore = create<PromptStore>((set, get) => ({
                 prompts
             }, null, 2);
 
-            const dataUri = `data:application/json;charset=utf-8,${encodeURIComponent(dataStr)}`;
             const exportName = `prompts-export-${new Date().toISOString().slice(0, 10)}.json`;
-
-            const linkElement = document.createElement('a');
-            linkElement.setAttribute('href', dataUri);
-            linkElement.setAttribute('download', exportName);
-            linkElement.click();
+            return await saveTextAsFile(dataStr, exportName, 'application/json');
         } catch (error) {
             set({ error: (error as Error).message });
             throw error;

--- a/src/features/stories/pages/Home.tsx
+++ b/src/features/stories/pages/Home.tsx
@@ -27,7 +27,7 @@ export default function Home() {
     };
 
     const handleExportStory = (story: Story) => {
-        storyExportService.exportStory(story.id);
+        void storyExportService.exportStory(story.id);
     };
 
     const handleImportClick = () => {

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -2,6 +2,7 @@ import { $generateHtmlFromNodes } from '@lexical/html';
 import { LexicalEditor } from 'lexical';
 import { Story, Chapter } from '@/types/story';
 import { db } from '@/services/database';
+import { saveTextAsFile } from '@/utils/fileDownload';
 
 /**
  * Converts Lexical JSON content to HTML
@@ -58,17 +59,8 @@ export async function convertLexicalToHtml(jsonContent: string): Promise<string>
  * @param filename The name of the file
  * @param contentType The MIME type of the content
  */
-export function downloadAsFile(content: string, filename: string, contentType: string) {
-    const blob = new Blob([content], { type: contentType });
-    const url = URL.createObjectURL(blob);
-
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-
-    // Clean up
-    URL.revokeObjectURL(url);
+export async function downloadAsFile(content: string, filename: string, contentType: string): Promise<boolean> {
+    return saveTextAsFile(content, filename, contentType);
 }
 
 /**
@@ -76,7 +68,7 @@ export function downloadAsFile(content: string, filename: string, contentType: s
  * @param storyId The ID of the story to download
  * @param format The format to download ('html' or 'text')
  */
-export async function downloadStory(storyId: string, format: 'html' | 'text') {
+export async function downloadStory(storyId: string, format: 'html' | 'text'): Promise<boolean> {
     try {
         // Get the story
         const story = await db.stories.get(storyId);
@@ -128,7 +120,7 @@ export async function downloadStory(storyId: string, format: 'html' | 'text') {
 </html>`;
 
             // Download the HTML file
-            downloadAsFile(htmlContent, `${story.title}.html`, 'text/html');
+            return await downloadAsFile(htmlContent, `${story.title}.html`, 'text/html');
         } else {
             // Create plain text content
             let textContent = `${story.title}\n`;
@@ -170,7 +162,7 @@ export async function downloadStory(storyId: string, format: 'html' | 'text') {
             }
 
             // Download the text file
-            downloadAsFile(textContent, `${story.title}.txt`, 'text/plain');
+            return await downloadAsFile(textContent, `${story.title}.txt`, 'text/plain');
         }
     } catch (error) {
         console.error('Failed to download story:', error);
@@ -183,7 +175,7 @@ export async function downloadStory(storyId: string, format: 'html' | 'text') {
  * @param chapterId The ID of the chapter to download
  * @param format The format to download ('html' or 'text')
  */
-export async function downloadChapter(chapterId: string, format: 'html' | 'text') {
+export async function downloadChapter(chapterId: string, format: 'html' | 'text'): Promise<boolean> {
     try {
         // Get the chapter
         const chapter = await db.chapters.get(chapterId);
@@ -226,7 +218,7 @@ export async function downloadChapter(chapterId: string, format: 'html' | 'text'
 </html>`;
 
             // Download the HTML file
-            downloadAsFile(htmlContent, `${story.title} - Chapter ${chapter.order}.html`, 'text/html');
+            return await downloadAsFile(htmlContent, `${story.title} - Chapter ${chapter.order}.html`, 'text/html');
         } else {
             // Create plain text content
             let textContent = `${story.title}\n`;
@@ -259,10 +251,10 @@ export async function downloadChapter(chapterId: string, format: 'html' | 'text'
             }
 
             // Download the text file
-            downloadAsFile(textContent, `${story.title} - Chapter ${chapter.order}.txt`, 'text/plain');
+            return await downloadAsFile(textContent, `${story.title} - Chapter ${chapter.order}.txt`, 'text/plain');
         }
     } catch (error) {
         console.error('Failed to download chapter:', error);
         throw error;
     }
-} 
+}

--- a/src/utils/fileDownload.ts
+++ b/src/utils/fileDownload.ts
@@ -1,0 +1,45 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1F]/g;
+
+function sanitizeExportFilename(filename: string): string {
+    const cleaned = filename
+        .trim()
+        .replace(INVALID_FILENAME_CHARS, "_")
+        .replace(/[. ]+$/g, "");
+
+    return cleaned.length > 0 ? cleaned : "export.txt";
+}
+
+function downloadInBrowser(content: string, filename: string, contentType: string): void {
+    const blob = new Blob([content], { type: contentType });
+    const url = URL.createObjectURL(blob);
+
+    const linkElement = document.createElement("a");
+    linkElement.href = url;
+    linkElement.download = filename;
+    linkElement.style.display = "none";
+
+    document.body.appendChild(linkElement);
+    linkElement.click();
+    linkElement.remove();
+
+    setTimeout(() => {
+        URL.revokeObjectURL(url);
+    }, 0);
+}
+
+export async function saveTextAsFile(content: string, filename: string, contentType: string): Promise<boolean> {
+    const safeFilename = sanitizeExportFilename(filename);
+
+    if (isTauri()) {
+        const savedPath = await invoke<string | null>("save_export_file", {
+            filename: safeFilename,
+            content,
+        });
+        return Boolean(savedPath);
+    }
+
+    downloadInBrowser(content, safeFilename, contentType);
+    return true;
+}


### PR DESCRIPTION
  This PR fixes export/download failures in the Tauri desktop build and adds a Save dialog flow for Tauri exports.

  # Problem
  Export actions were implemented with browser-style data: / Blob + <a download> triggers. In the Tauri webview, those actions could fail
  silently, so users clicked export/download and nothing happened.

  # Root Cause
  Multiple export paths relied on browser-only download behavior instead of a Tauri-native file write flow.

  # What Changed

  1. Added a shared save helper that works in both browser and Tauri:

  - src/utils/fileDownload.ts:1
  - In Tauri, it calls invoke("save_export_file").
  - In browser, it keeps Blob download behavior.
  - It returns Promise<boolean> so callers can detect cancel/no-save.

  2. Added a new Tauri command for exports:

  - src-tauri/src/lib.rs:14
  - New command: save_export_file(app, filename, content) -> Result<Option<String>, String>.
  - Sanitizes filenames before writing.
  - Creates parent dirs as needed.
  - Returns None when user cancels.

  3. Added native Save dialog behavior on macOS:

  - src-tauri/src/lib.rs:53
  - Uses osascript (choose file name) with prefilled default filename and default export directory (Downloads, fallback Documents).

  4. Updated all export/download paths to use the shared helper instead of anchor downloads:

  - src/utils/exportUtils.ts:62
  - src/services/storyExportService.ts:21
  - src/features/prompts/store/promptStore.ts:19
  - src/features/lorebook/stores/useLorebookStore.ts:49

  5. Updated UI handlers to respect cancel (no false-success toast if dialog is canceled):

  - src/components/ui/DownloadMenu.tsx:31
  - src/features/prompts/components/PromptsManager.tsx:94
  - src/features/lorebook/pages/LorebookPage.tsx:45

  6. Minor call-site adjustment for async return:

  - src/features/stories/pages/Home.tsx:29

  # Behavior After This PR

  - Tauri on macOS: export opens Save dialog with suggested filename.
  - If user cancels Save dialog: no success toast, no error toast.
  - Browser build: existing download behavior is preserved.
  - Non-macOS Tauri: currently still uses auto-save into Downloads/Documents fallback path (collision-safe filename suffixing).

  # API/Type Changes

  - Export methods that previously returned Promise<void> now return Promise<boolean> in relevant store/service/helper paths to indicate
    whether a file was actually saved.
