### PR TITLE
fix: resolve critical bugs, sync upstream features, and improve stability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md — The Story Nexus (Fork)
+
+## Project Overview
+
+**The Story Nexus** is a local-first AI-assisted creative writing desktop application built with Tauri v2 + React + TypeScript. Users write stories with chapters, use a Lexical-based rich text editor, and generate prose via AI (local models via LMStudio, OpenAI, OpenRouter, NanoGPT, or any OpenAI-compatible endpoint).
+
+**Upstream repo**: `vijayk1989/TheStoryNexusTauriApp` (AGPL-3.0)
+**This fork**: Personal enhancements on top of upstream. Do not push changes back to the upstream origin without the owner's explicit permission.
+
+**License**: GNU Affero General Public License v3.0 (AGPL-3.0). All modifications must remain under AGPL-3.0. See `LICENSE` for full text.
+
+---
+
+## Key Commands
+
+```bash
+npm install          # Install dependencies
+npm run dev          # Dev server (web preview)
+npm run tauri dev    # Full Tauri desktop app (development)
+npm run build        # Build web assets
+npm run tauri build  # Build desktop binary
+npm run tauri build -- --debug  # Debug desktop binary
+```
+
+---
+
+## Architecture
+
+### Technology Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Desktop shell | Tauri v2 (Rust) |
+| Frontend | React 18 + TypeScript + Vite |
+| Styling | Tailwind CSS + Shadcn UI |
+| State | Zustand (in-memory) |
+| Routing | React Router v7 |
+| Persistence | IndexedDB via DexieJS (local-first, no server) |
+| Editor | Lexical (Meta's rich text framework) |
+| Notifications | React Toastify |
+
+### Directory Structure
+
+```
+src/
+├── features/           # Feature modules (stories, chapters, agents, prompts, lorebook…)
+│   ├── agents/         # Multi-agent pipeline system (AgentsManager, pipelines)
+│   ├── ai/             # AI settings panel + store
+│   ├── chapters/       # Chapter editor, StoryEditor, chapter store
+│   ├── scenebeats/     # Scene beat nodes + generation hooks
+│   ├── prompts/        # Prompt management + store
+│   ├── lorebook/       # Character/location/item/event database
+│   ├── stories/        # Story list, dashboard
+│   ├── drafts/         # Draft saving per scene beat
+│   └── brainstorm/     # AI brainstorm/chat feature
+├── services/
+│   ├── ai/
+│   │   ├── AIService.ts          # Unified LLM provider (local/openai/openrouter/…)
+│   │   └── AgentOrchestrator.ts  # Multi-step pipeline executor
+│   └── database.ts               # Dexie schema (currently v15)
+├── types/story.ts      # ALL shared TypeScript types
+├── Lexical/            # Lexical editor playground + custom plugins
+└── components/         # Shared UI components
+```
+
+### Data Persistence
+
+All data lives in **IndexedDB** (via Dexie). Tables:
+
+| Table | Contents |
+|-------|---------|
+| `stories` | Story metadata |
+| `chapters` | Chapter content (Lexical JSON), outline, notes |
+| `sceneBeats` | Scene beat commands + generated content |
+| `drafts` | Saved generation outputs per scene beat |
+| `aiSettings` | API keys, local URL, model list, favourites |
+| `prompts` | User + system prompt templates |
+| `lorebookEntries` | Characters, locations, items, events, notes |
+| `agentPresets` | Agent configurations (role, model, system prompt) |
+| `pipelinePresets` | Multi-step agent workflows |
+| `pipelineExecutions` | Execution history |
+
+**Chapter content** is auto-saved 1 second after the last keystroke via `SaveChapterContentPlugin`. There is currently no unsaved-indicator in the UI.
+
+Selected model/prompt/pipeline in the scene beat panel is **in-memory only** (Zustand, not persisted) — users must re-select on every reload. This is a known issue to fix.
+
+---
+
+## AI / LLM Architecture
+
+### Providers (AIService.ts)
+
+- `local` → LMStudio at `http://localhost:1234/v1` (configurable URL)
+- `openai` → OpenAI API (requires key)
+- `openrouter` → OpenRouter (requires key)
+- `nanogpt` → NanoGPT (requires key)
+- `openai_compatible` → Custom endpoint (Ollama, vLLM, etc.)
+
+All providers stream SSE and share `processStreamedResponse()` for token handling. `abortStream()` cancels the current in-flight request.
+
+### Agentic Pipeline (AgentOrchestrator.ts)
+
+Agents run sequentially. Each step:
+1. Builds messages (`buildMessages`) — system + user, or multi-turn for revisions
+2. Calls the appropriate LLM provider (`callModel`)
+3. Streams (final prose steps) or collects (judge/checker steps)
+4. Stores result; next step can reference previous results
+
+**Revision loops**: A step with `isRevision: true` + `pushPrompt` builds a 4-message conversation: `[system, originalUser, assistantPreviousOutput, pushPromptUser]`.
+
+**Known issue**: `generateWithLocalModel` currently hardcodes `model: 'local/llama-3.2-3b-instruct'` — the configured model ID is not passed through. This breaks agentic local model selection.
+
+### Agent Roles
+
+`prose_writer`, `lore_judge`, `continuity_checker`, `style_editor`, `dialogue_specialist`, `expander`, `summarizer`, `outline_generator`, `style_extractor`, `scenebeat_generator`, `refusal_checker`, `chapter_reviewer` (upstream), `chapter_editor` (upstream), `custom`
+
+---
+
+## Branching Policy
+
+- **`main`** — stable, no direct commits. PRs only.
+- Feature work lives in `feature/*` branches.
+- All the improvements tracked in `IMPLEMENTATION_PLAN.md` are being implemented on `feature/improvements`.
+
+---
+
+## Known Issues (pre-fix)
+
+See `IMPLEMENTATION_PLAN.md` for the full breakdown. TL;DR:
+
+1. **Hardcoded local model** — `AIService.generateWithLocalModel` ignores the configured model ID.
+2. **Scene beat settings not persisted** — selected model/prompt/pipeline resets on reload.
+3. **Auto-save data loss edge case** — debounce is cancelled on unmount; rapid navigation may lose the last ~1s of edits.
+4. **Revision loop uses stale result** — always picks the first `prose_writer` result rather than the most recent one.
+5. **Upstream features missing** — `chapter_reviewer`/`chapter_editor` roles, `AIEditorialPanel`, bulk operations, and `resetSystemDefaults` are in upstream but not yet in this fork.
+
+---
+
+## Coding Conventions
+
+- TypeScript strict mode; no `any` except in legacy AI request bodies.
+- Zustand stores handle all state; components call store actions.
+- Database writes always go through the store (never direct `db.*` calls from components).
+- New agent roles require changes in: `types/story.ts` (role union + DEFAULT_CONTEXT_CONFIG), `AgentOrchestrator.ts` (buildXxxMessage), `agentSeeder.ts` (SYSTEM_AGENT_PRESETS), `useAgentsStore.ts` (role label map).
+- Keep the Dexie schema version incremented when adding/changing tables or indexes.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,304 @@
+# Implementation Plan — Story Nexus Fork Improvements
+
+**Branch**: `feature/improvements`
+**Status**: In planning
+**Last updated**: 2026-03-12
+
+---
+
+## Step 0 — Create Feature Branch ⚠️ DO THIS FIRST
+
+```bash
+git checkout -b feature/improvements
+```
+
+All work in this plan goes on `feature/improvements`. Nothing is committed directly to `main`.
+
+---
+
+## Background
+
+This fork is based on `vijayk1989/TheStoryNexusTauriApp` (AGPL-3.0). The upstream repo has moved 2 commits ahead since the fork point (`3f927bf`), adding chapter editorial features. Additionally, this fork has a number of bugs and UX issues that need addressing.
+
+### What the upstream added (commits `261b550` + `97ad554`):
+- `chapter_reviewer` and `chapter_editor` agent roles
+- `AIEditorialPanel.tsx` + `ChapterReviewPanel.tsx` components
+- `BulkUpdatePanel.tsx` shared component
+- Bulk operations on agents, pipelines, and prompts
+- `resetSystemDefaults()` to force-reseed system agents
+- Force mode in `agentSeeder` (wipe + recreate system agents)
+- Updated `StoryEditor.tsx` with AI Editorial side panel
+
+---
+
+## Step 1 — Bring Upstream Changes into Fork
+
+Bring the 2 upstream commits' changes (files differing between orig and fork) into the feature branch.
+
+### Files to copy/update from orig → fork
+
+**New files (create):**
+- [ ] `src/components/BulkUpdatePanel.tsx`
+- [ ] `src/features/chapters/components/AIEditorialPanel.tsx`
+- [ ] `src/features/chapters/components/ChapterReviewPanel.tsx`
+
+**Modified files (patch):**
+- [ ] `src/types/story.ts`
+  - Add `isValid?: boolean` to Draft interface
+  - Add `"chapter_reviewer"` and `"chapter_editor"` to AgentRole union type
+  - Add context config entries for `chapter_reviewer` and `chapter_editor` in DEFAULT_CONTEXT_CONFIG
+
+- [ ] `src/services/ai/AgentOrchestrator.ts`
+  - Add `case 'chapter_reviewer':` and `case 'chapter_editor':` to role dispatch
+  - Add `buildChapterReviewerMessage()` private method
+  - Add `buildChapterEditorMessage()` private method
+
+- [ ] `src/features/agents/services/agentSeeder.ts`
+  - Add `chapter_reviewer` and `chapter_editor` to CONTEXT_CONFIGS map
+  - Add System Chapter Reviewer agent preset
+  - Add System Chapter Editor agent preset
+  - Add 4 new pipeline presets: Chapter Review, Chapter Deep Review, Chapter Edit, Chapter Review then Edit
+  - Add force mode: when `force=true`, delete existing system agents/pipelines before reseeding
+
+- [ ] `src/features/agents/stores/useAgentsStore.ts`
+  - Add `chapter_reviewer` and `chapter_editor` to role label map
+  - Add `bulkUpdateAgentPresets(ids, data)` action
+  - Add `bulkUpdateAgentModel(ids, model)` action
+  - Add `bulkUpdatePipelinePresets(ids, data)` action
+  - Add `resetSystemDefaults(storyId?)` action
+
+- [ ] `src/features/prompts/store/promptStore.ts`
+  - Add `bulkUpdatePrompts(ids, data)` action
+
+- [ ] `src/features/chapters/components/StoryEditor.tsx`
+  - Add `AIEditorialPanel` import
+  - Add `"chapterReview"` to `DrawerType` union
+  - Add AI Editorial button to toolbar
+  - Add AI Editorial sheet with drag-to-resize handle
+  - Wire `editorialWidth` state + `startEditorialDrag` handler
+
+- [ ] `src/features/agents/components/AgentPresetForm.tsx` — sync with upstream
+- [ ] `src/features/agents/components/AgentPresetList.tsx` — sync with upstream
+- [ ] `src/features/agents/components/AgentsManager.tsx` — sync with upstream
+- [ ] `src/features/agents/components/PipelinePresetForm.tsx` — sync with upstream
+- [ ] `src/features/agents/components/PipelinePresetList.tsx` — sync with upstream
+- [ ] `src/features/prompts/components/PromptList.tsx` — sync with upstream
+- [ ] `src/features/prompts/components/PromptsManager.tsx` — sync with upstream
+
+---
+
+## Step 2 — Critical Bug Fixes
+
+### Bug 2A — Hardcoded Local Model in AIService (**HIGH PRIORITY**)
+
+**File**: `src/services/ai/AIService.ts` line 365
+**Problem**: `generateWithLocalModel()` always sends `model: 'local/llama-3.2-3b-instruct'` regardless of which local model is configured on an agent or prompt. This means every local model call uses the same hardcoded model.
+
+**Fix**:
+- Add `modelId?: string` parameter to `generateWithLocalModel()`
+- Use `modelId` in the request body; fall back to the first available local model from `this.settings.availableModels` if not provided
+- Strip the `local/` prefix from model IDs when sending to the LMStudio API (LMStudio uses bare IDs like `llama-3.2-3b-instruct`, not `local/llama-3.2-3b-instruct`)
+
+**Cascading fix in AgentOrchestrator.ts**:
+- In `callModel()`, pass `model.id` (or the bare ID without `local/`) to `generateWithLocalModel()`
+- Also update `useAIStore.ts` and `useSceneBeatInstanceStore.ts` calls to pass the model ID
+
+### Bug 2B — Revision Loop Uses Stale Prose Result (**HIGH PRIORITY**)
+
+**File**: `src/services/ai/AgentOrchestrator.ts` line 302
+**Problem**: `buildMessages()` for revision mode calls `previousResults.find(r => r.role === 'prose_writer')` which returns the FIRST prose_writer result. In a multi-iteration revision loop, this means the AI is always shown its original (pre-revision) output as the "previous output", not the most recent revised version.
+
+**Fix**: Replace `.find()` with a reverse search to get the most recent prose_writer result:
+```typescript
+// Instead of:
+const proseResult = previousResults.find(r => r.role === 'prose_writer');
+// Use:
+const proseResult = [...previousResults].reverse().find(r => r.role === 'prose_writer');
+```
+
+### Bug 2C — AbortController Shared Between Pipeline Steps (**MEDIUM**)
+
+**File**: `src/services/ai/AIService.ts`
+**Problem**: Every call to `generateWithLocalModel()` (and other generate methods) creates a new `AbortController` and stores it as `this.abortController`. Since the `AIService` is a singleton, this shared mutable state means:
+1. If two pipeline steps run in rapid succession (shouldn't normally happen, but possible), one step could abort the other.
+2. The `AgentOrchestrator` has its own `abortController` but doesn't share it with `AIService` — abort signals come from two places.
+
+**Fix**: Pass an optional `AbortSignal` parameter down through `callModel()` and into each `generateWith*()` method instead of creating a new controller internally. The orchestrator passes its own signal; standalone generation creates its own.
+
+---
+
+## Step 3 — Settings & State Persistence
+
+### Issue 3A — Scene Beat Model/Prompt/Pipeline Not Persisted (**HIGH PRIORITY**)
+
+**File**: `src/features/scenebeats/stores/useSceneBeatInstanceStore.ts`
+**Problem**: `selectedModel`, `selectedPrompt`, `selectedPipeline`, and `agenticMode` are Zustand state only. On app reload, these all reset to `undefined`/`false`. Users must re-select their entire scene beat configuration on every session.
+
+**Fix**:
+- Persist `selectedPromptId`, `selectedModelId`, `selectedPipelineId`, and `agenticMode` to `localStorage` (simple key-value, these are cheap to store)
+- On store initialisation, restore these values from localStorage
+- After restoring IDs, hydrate the full objects from the prompt/model stores
+- Update `handlePromptSelect` and related actions to also write to localStorage
+
+**Implementation approach** — add an `initFromStorage()` action called from App startup:
+```typescript
+// Keys to persist
+const STORAGE_KEYS = {
+  promptId: 'scenebeat-selected-prompt-id',
+  modelId: 'scenebeat-selected-model-id',
+  pipelineId: 'scenebeat-selected-pipeline-id',
+  agenticMode: 'scenebeat-agentic-mode',
+};
+```
+
+### Issue 3B — AI Settings Panel Re-initialization (**MEDIUM**)
+
+**File**: `src/features/ai/stores/useAIStore.ts`
+**Problem**: API keys and URLs ARE saved to IndexedDB and DO persist across reloads. However, the `isInitialized` flag is in-memory, so `initialize()` runs on every app start. If `initialize()` is called multiple times (e.g., multiple components calling `getAvailableModels` before the first call resolves), there's no deduplication guard.
+
+**Fix**: Add an `_initPromise` singleton guard so concurrent `initialize()` calls share one promise:
+```typescript
+private _initPromise: Promise<void> | null = null;
+initialize: async () => {
+  if (get().isInitialized) return;
+  if (_initPromise) return _initPromise;
+  _initPromise = /* actual init */;
+  await _initPromise;
+  _initPromise = null;
+}
+```
+
+---
+
+## Step 4 — Story / Data Safety
+
+### Issue 4A — Debounce Cancelled on Fast Navigation (**MEDIUM**)
+
+**File**: `src/Lexical/lexical-playground/src/plugins/SaveChapterContent/index.tsx`
+**Problem**: The `SaveChapterContentPlugin` debounces writes by 1 second. When the `useEffect` cleanup runs (on chapter switch or component unmount), `saveContent.cancel()` is called — discarding any pending save. If a user types and immediately navigates away, up to 1 second of edits can be lost silently.
+
+**Fix**: On cleanup, call `saveContent.flush()` instead of (or in addition to) `saveContent.cancel()` — this forces any pending debounced write to fire synchronously:
+```typescript
+return () => {
+  removeUpdateListener();
+  saveContent.flush(); // persist pending edits before unmounting
+};
+```
+
+### Issue 4B — No Unsaved Indicator (**LOW/UX**)
+
+**Problem**: Users have no visual feedback that their edits are being saved. The auto-save is silent.
+
+**Fix**: Add a small "Saving…" / "Saved" status indicator in the `StoryEditor` toolbar. The `SaveChapterContentPlugin` can emit save state via a Zustand flag (`isSaving: boolean` in `useChapterStore` or a dedicated editor state).
+
+### Issue 4C — Agent Pipeline Execution Not Linked to Draft (**LOW**)
+
+**Problem**: When an agentic pipeline produces prose, there's no automatic "save draft" step. If the app reloads before the user explicitly saves, the output is lost.
+
+**Fix**: After a successful pipeline execution, automatically save the result as a `Draft` record in IndexedDB (same as what `saveDraft()` does for standard generation). Mark it as auto-saved so users can distinguish it from intentional drafts.
+
+---
+
+## Step 5 — Agentic Workflow Improvements
+
+### Issue 5A — Agentic Pipeline Context for Revision Steps (**MEDIUM**)
+
+**Problem**: In `buildMessages()` for revision mode, the "original user message" is always rebuilt from scratch using `buildProseWriterMessage(agent, input, [], false)` — ignoring any previous step outputs. This means the revision prompt sees the raw scene beat context but not any intermediate judge feedback that might have been incorporated into the original user message.
+
+**Fix**: Store the original user message in the `AgentResult` metadata when the prose writer step first runs, so revision steps can replay the exact original conversation.
+
+### Issue 5B — Agentic Mode: Non-streaming Steps Use Wrong Model Config (**HIGH**)
+*See also Bug 2A* — same root cause. All local model calls use the hardcoded model.
+
+### Issue 5C — Pipeline Progress Feedback (**LOW/UX**)
+
+**Problem**: The agentic progress UI shows step names but doesn't show token counts, elapsed time per step, or which model is running.
+
+**Fix**: Emit richer progress events from `AgentOrchestrator` callbacks: add `tokensGenerated` to `onStepComplete`, add `modelName` to `onStepStart`.
+
+### Issue 5D — Model ID Stripping for LMStudio (**HIGH**)
+
+**Problem**: Local models in the app are stored with IDs prefixed `local/` (e.g., `local/llama-3.2-3b-instruct`). LMStudio's API expects the bare model ID without the prefix. Currently this is only handled implicitly by the hardcoded model string. Once we fix Bug 2A and pass real model IDs, we must also strip the `local/` prefix before sending to LMStudio.
+
+**Fix**: In `generateWithLocalModel()`, strip the `local/` prefix:
+```typescript
+const bareModelId = modelId.replace(/^local\//, '');
+```
+
+---
+
+## Step 6 — Code Quality & Stability
+
+### Issue 6A — Debug Console Logs in promptParser.ts (**LOW**)
+
+**File**: `src/features/prompts/services/promptParser.ts`
+**Problem**: Extensive `console.log` DEBUG statements left in production code (lines ~501–618). These spam the console and may expose user content in logs.
+
+**Fix**: Remove or gate behind a `DEBUG` flag.
+
+### Issue 6B — `any` Type in AI Request Bodies (**LOW**)
+
+**Files**: `AIService.ts` — `requestBody: any`
+**Fix**: Create a typed `LMStudioChatRequest` interface.
+
+### Issue 6C — Error Handling in Standard Generation (**MEDIUM**)
+
+**Problem**: If standard (non-agentic) generation fails, the error is shown as a toast but the streaming state may be left in `streaming: true`. This can lock the UI until reload.
+
+**Fix**: Ensure the `finally` block in `useSceneBeatGeneration.ts` always resets `streaming: false`.
+
+---
+
+## Step 7 — Testing & Validation
+
+- [ ] Manually test: create a story → chapter → type content → switch chapter → return → verify content intact (tests Issue 4A fix)
+- [ ] Manually test: set LMStudio URL + select local model → reload app → verify URL persists AND model selection is restored (tests Issues 3A, 3B)
+- [ ] Manually test: run an agentic pipeline with a local model → verify the agent's configured model is actually used (tests Bug 2A)
+- [ ] Manually test: run a pipeline with a revision step → verify the push prompt shows the MOST RECENT prose output (tests Bug 2B)
+- [ ] Manually test: abort mid-pipeline → verify no hung state
+- [ ] Manually test: AI Editorial panel opens and runs chapter review
+
+---
+
+## Priority Order Summary
+
+| Priority | Step | Description |
+|----------|------|-------------|
+| 🔴 P0 | 0 | Create feature branch |
+| 🔴 P1 | 1 | Bring upstream changes (chapter reviewer/editor, bulk ops) |
+| 🔴 P1 | 2A | Fix hardcoded local model (breaks all agentic local generation) |
+| 🔴 P1 | 2D | Fix `local/` prefix stripping for LMStudio |
+| 🟠 P2 | 2B | Fix revision loop stale result |
+| 🟠 P2 | 3A | Persist scene beat model/prompt/pipeline selection |
+| 🟠 P2 | 4A | Fix debounce flush on unmount (data loss) |
+| 🟡 P3 | 3B | Fix duplicate initialize() calls |
+| 🟡 P3 | 2C | AbortController refactor |
+| 🟡 P3 | 6C | Fix streaming state left dirty on error |
+| 🟢 P4 | 4B | Unsaved indicator in toolbar |
+| 🟢 P4 | 4C | Auto-save pipeline output as draft |
+| 🟢 P4 | 5A | Store original user message in AgentResult metadata |
+| 🟢 P4 | 5C | Richer pipeline progress events |
+| 🟢 P5 | 6A | Remove debug logs |
+| 🟢 P5 | 6B | Type AI request bodies |
+
+---
+
+## Progress Tracker
+
+- [x] Step 0 — Feature branch created (`feature/improvements`)
+- [x] Step 1 — Upstream changes synced (cherry-picked commits 261b550 + 97ad554)
+- [x] Step 2A — Hardcoded model fix (`AIService.generateWithLocalModel` now accepts `modelId`)
+- [x] Step 2B — Revision loop fix (now uses most recent prose result, not first)
+- [ ] Step 2C — AbortController refactor *(deferred — lower priority)*
+- [x] Step 2D — `local/` prefix stripped before sending to LMStudio
+- [x] Step 3A — Scene beat persistence (`localStorage` via `saveSBDefaults` + `hydrateFromDefaults`)
+- [x] Step 3B — Init dedup (`_initPromise` singleton guard in `useAIStore`)
+- [x] Step 4A — Debounce flush on unmount (`saveContent.flush()` instead of cancel)
+- [x] Step 4B — Save indicator in StoryEditor sidebar (`saving…` / `Saved ✓`)
+- [ ] Step 4C — Auto-save pipeline output as draft *(deferred)*
+- [ ] Step 5A — Store original message in AgentResult metadata *(deferred)*
+- [ ] Step 5C — Pipeline progress enrichment *(deferred)*
+- [x] Step 6A — Debug logs removed from `promptParser.ts`
+- [ ] Step 6B — Type request bodies *(deferred)*
+- [x] Step 6C — Streaming state always reset on agentic error/complete
+- [ ] Step 7 — Manual testing complete *(pending)*

--- a/src/Lexical/lexical-playground/src/nodes/SceneBeatNode.tsx
+++ b/src/Lexical/lexical-playground/src/nodes/SceneBeatNode.tsx
@@ -112,13 +112,19 @@ function SceneBeatInner({ nodeKey }: { nodeKey: NodeKey }) {
 
   // ── Effects ──────────────────────────────────────────────────
 
-  // Fetch prompts on mount
+  const hydrateFromDefaults = useSBStore((s) => s.hydrateFromDefaults);
+
+  // Fetch prompts on mount, then hydrate defaults from localStorage
   useEffect(() => {
-    gen.fetchPrompts().catch((error: unknown) => {
+    gen.fetchPrompts().then(() => {
+      // After prompts are loaded, restore last-used selection
+      const loadedPrompts = usePromptStore.getState().prompts;
+      hydrateFromDefaults(loadedPrompts, []);
+    }).catch((error: unknown) => {
       toast.error("Failed to load prompts");
       console.error("Error loading prompts:", error);
     });
-  }, [gen.fetchPrompts]);
+  }, [gen.fetchPrompts, hydrateFromDefaults]);
 
   // Load available pipelines when agentic mode is enabled
   const agenticMode = useSBStore((s) => s.agenticMode);
@@ -126,7 +132,11 @@ function SceneBeatInner({ nodeKey }: { nodeKey: NodeKey }) {
     if (agenticMode) {
       gen.getAvailablePipelines().then((pipelines: any) => {
         set({ availablePipelines: pipelines });
-        if (pipelines.length > 0 && !selectedPipeline) {
+        // Hydrate pipeline default now that we have the list
+        const loadedPrompts = usePromptStore.getState().prompts;
+        hydrateFromDefaults(loadedPrompts, pipelines);
+        // If still no pipeline selected after hydration, pick the first
+        if (pipelines.length > 0 && !storeApi.getState().selectedPipeline) {
           set({ selectedPipeline: pipelines[0] });
         }
       }).catch((error: unknown) => {
@@ -134,7 +144,7 @@ function SceneBeatInner({ nodeKey }: { nodeKey: NodeKey }) {
         toast.error("Failed to load AI pipelines");
       });
     }
-  }, [agenticMode, gen.getAvailablePipelines]);
+  }, [agenticMode, gen.getAvailablePipelines, hydrateFromDefaults]);
 
   // Get sceneBeatId from node
   useEffect(() => {

--- a/src/Lexical/lexical-playground/src/plugins/SaveChapterContent/index.tsx
+++ b/src/Lexical/lexical-playground/src/plugins/SaveChapterContent/index.tsx
@@ -1,31 +1,39 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { useChapterStore } from '@/features/chapters/stores/useChapterStore';
 import { useStoryContext } from '@/features/stories/context/StoryContext';
-import { toast } from 'react-toastify';
-import { TOAST_CLOSE_TIMER, TOAST_POSITION } from '@/constants';
 import { debounce } from 'lodash';
-import { $isSceneBeatNode } from '../../nodes/SceneBeatNode';
-import { $getRoot, $getNodeByKey } from 'lexical';
 
 export function SaveChapterContentPlugin(): null {
     const [editor] = useLexicalComposerContext();
     const { currentChapterId } = useStoryContext();
     const { updateChapter } = useChapterStore();
+    const setSaveStatus = useChapterStore((s) => s.saveStatus !== undefined
+        ? (status: 'idle' | 'saving' | 'saved') => useChapterStore.setState({ saveStatus: status })
+        : () => {});
+
+    // Track the "saved" timer so we can clear it on each new save
+    const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Debounced save function
     const saveContent = useCallback(
         debounce((content: string) => {
-            if (currentChapterId) {
-                console.log('SaveChapterContent - Saving content for chapter:', currentChapterId);
-                updateChapter(currentChapterId, { content })
-                    .then(() => {
-                        console.log('SaveChapterContent - Content saved successfully');
-                    })
-                    .catch((error) => {
-                        console.error('SaveChapterContent - Failed to save content:', error);
-                    });
-            }
+            if (!currentChapterId) return;
+
+            useChapterStore.setState({ saveStatus: 'saving' });
+            updateChapter(currentChapterId, { content })
+                .then(() => {
+                    useChapterStore.setState({ saveStatus: 'saved' });
+                    // Auto-clear "Saved" indicator after 2 seconds
+                    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+                    savedTimerRef.current = setTimeout(() => {
+                        useChapterStore.setState({ saveStatus: 'idle' });
+                    }, 2000);
+                })
+                .catch((error) => {
+                    console.error('SaveChapterContent - Failed to save content:', error);
+                    useChapterStore.setState({ saveStatus: 'idle' });
+                });
         }, 1000),
         [currentChapterId, updateChapter]
     );
@@ -36,22 +44,26 @@ export function SaveChapterContentPlugin(): null {
 
         const removeUpdateListener = editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
             // Skip if no changes
-            if (dirtyElements.size === 0 && dirtyLeaves.size === 0) {
-                return;
-            }
+            if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
 
-            // Get the editor state as JSON
             const content = JSON.stringify(editorState.toJSON());
-
-            // Save the content
             saveContent(content);
         });
 
         return () => {
             removeUpdateListener();
-            saveContent.cancel();
+            // Flush any pending debounced save before unmounting to prevent data loss
+            // when the user navigates away within the 1-second debounce window.
+            saveContent.flush();
         };
     }, [editor, currentChapterId, saveContent]);
+
+    // Cleanup timer on unmount
+    useEffect(() => {
+        return () => {
+            if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+        };
+    }, []);
 
     return null;
 }

--- a/src/components/BulkUpdatePanel.tsx
+++ b/src/components/BulkUpdatePanel.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { X } from 'lucide-react';
+import { toast } from 'react-toastify';
+import { AIService } from '@/services/ai/AIService';
+import type { AllowedModel, AIModel } from '@/types/story';
+
+interface BulkUpdatePanelProps {
+    selectedCount: number;
+    isVisible: boolean;
+    onClose: () => void;
+    onApplyModel: (model: AllowedModel) => Promise<void>;
+    isApplying?: boolean;
+}
+
+export function BulkUpdatePanel({
+    selectedCount,
+    isVisible,
+    onClose,
+    onApplyModel,
+    isApplying = false,
+}: BulkUpdatePanelProps) {
+    const [availableModels, setAvailableModels] = useState<AIModel[]>([]);
+    const [selectedModel, setSelectedModel] = useState<string>('');
+    const [isLoadingModels, setIsLoadingModels] = useState(false);
+
+    useEffect(() => {
+        if (isVisible) {
+            loadModels();
+        }
+    }, [isVisible]);
+
+    const loadModels = async () => {
+        setIsLoadingModels(true);
+        try {
+            const aiService = AIService.getInstance();
+            const models = await aiService.getAvailableModels(undefined, true);
+            setAvailableModels(models);
+            if (models.length > 0) {
+                setSelectedModel(models[0].id);
+            }
+        } catch (error) {
+            console.error('Failed to load models:', error);
+            toast.error('Failed to load available models');
+        } finally {
+            setIsLoadingModels(false);
+        }
+    };
+
+    const handleApply = async () => {
+        if (!selectedModel) {
+            toast.error('Please select a model');
+            return;
+        }
+
+        const selectedModelObj = availableModels.find(m => m.id === selectedModel);
+        if (!selectedModelObj) {
+            toast.error('Selected model not found');
+            return;
+        }
+
+        const allowedModel: AllowedModel = {
+            id: selectedModelObj.id,
+            provider: selectedModelObj.provider,
+            name: selectedModelObj.name,
+        };
+
+        try {
+            await onApplyModel(allowedModel);
+            toast.success(`Applied to ${selectedCount} item(s)`);
+            onClose();
+        } catch (error) {
+            toast.error((error as Error).message || 'Failed to update items');
+        }
+    };
+
+    if (!isVisible) {
+        return null;
+    }
+
+    return (
+        <div className="fixed bottom-0 left-0 right-0 border-t border-input bg-background p-4 shadow-lg z-40">
+            <div className="max-w-7xl mx-auto">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-4 flex-1">
+                        <div className="text-sm font-medium">
+                            {selectedCount} item{selectedCount !== 1 ? 's' : ''} selected
+                        </div>
+                        <div className="flex items-center gap-2 flex-1">
+                            <span className="text-sm text-muted-foreground">Update model:</span>
+                            <Select value={selectedModel} onValueChange={setSelectedModel} disabled={isApplying}>
+                                <SelectTrigger className="w-[250px]">
+                                    <SelectValue placeholder="Select a model..." />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {isLoadingModels ? (
+                                        <SelectItem value="loading" disabled>
+                                            Loading models...
+                                        </SelectItem>
+                                    ) : availableModels.length === 0 ? (
+                                        <SelectItem value="no-models" disabled>
+                                            No models available
+                                        </SelectItem>
+                                    ) : (
+                                        availableModels.map((model) => (
+                                            <SelectItem key={model.id} value={model.id}>
+                                                {model.name} ({model.provider})
+                                            </SelectItem>
+                                        ))
+                                    )}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            onClick={handleApply}
+                            disabled={isApplying || !selectedModel}
+                            size="sm"
+                        >
+                            {isApplying ? 'Applying...' : 'Apply'}
+                        </Button>
+                        <Button
+                            onClick={onClose}
+                            variant="outline"
+                            size="icon"
+                            disabled={isApplying}
+                        >
+                            <X className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/agents/components/AgentPresetForm.tsx
+++ b/src/features/agents/components/AgentPresetForm.tsx
@@ -59,6 +59,8 @@ const AGENT_ROLES: { value: AgentRole; label: string; description: string }[] = 
     { value: 'outline_generator', label: 'Outline Generator', description: 'Generates structured story/chapter outlines' },
     { value: 'style_extractor', label: 'Style Extractor', description: 'Analyzes text to extract writing style' },
     { value: 'scenebeat_generator', label: 'Scene Beat Generator', description: 'Generates scene beat commands' },
+    { value: 'chapter_reviewer', label: 'Chapter Reviewer', description: 'Reviews an entire chapter for quality, consistency, and suggestions' },
+    { value: 'chapter_editor', label: 'Chapter Editor', description: 'Rewrites/edits an entire chapter based on instructions' },
     { value: 'custom', label: 'Custom', description: 'User-defined agent role' },
 ];
 

--- a/src/features/agents/components/AgentPresetList.tsx
+++ b/src/features/agents/components/AgentPresetList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -20,12 +21,14 @@ import {
 } from '@/components/ui/alert-dialog';
 import { MoreVertical, Edit, Trash2, Copy, Bot } from 'lucide-react';
 import { useAgentsStore } from '../stores/useAgentsStore';
-import type { AgentPreset, AgentRole } from '@/types/story';
+import type { AgentPreset, AgentRole, AllowedModel } from '@/types/story';
 import { toast } from 'react-toastify';
 
 interface AgentPresetListProps {
     agents: AgentPreset[];
     onEdit: (agent: AgentPreset) => void;
+    selectedAgentIds?: string[];
+    onSelectionChange?: (ids: string[]) => void;
 }
 
 const ROLE_COLORS: Record<AgentRole, string> = {
@@ -62,10 +65,26 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     custom: 'Custom',
 };
 
-export function AgentPresetList({ agents, onEdit }: AgentPresetListProps) {
+export function AgentPresetList({ agents, onEdit, selectedAgentIds = [], onSelectionChange }: AgentPresetListProps) {
     const { deleteAgentPreset, createAgentPreset } = useAgentsStore();
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [agentToDelete, setAgentToDelete] = useState<AgentPreset | null>(null);
+
+    const handleToggleSelect = (agentId: string) => {
+        const newSelection = selectedAgentIds.includes(agentId)
+            ? selectedAgentIds.filter(id => id !== agentId)
+            : [...selectedAgentIds, agentId];
+        onSelectionChange?.(newSelection);
+    };
+
+    const handleSelectAllInGroup = (roleAgents: AgentPreset[]) => {
+        const agentIdsInGroup = roleAgents.map(a => a.id);
+        const allSelected = agentIdsInGroup.every(id => selectedAgentIds.includes(id));
+        const newSelection = allSelected
+            ? selectedAgentIds.filter(id => !agentIdsInGroup.includes(id))
+            : [...new Set([...selectedAgentIds, ...agentIdsInGroup])];
+        onSelectionChange?.(newSelection);
+    };
 
     const handleDelete = async () => {
         if (!agentToDelete) return;
@@ -125,35 +144,64 @@ export function AgentPresetList({ agents, onEdit }: AgentPresetListProps) {
     return (
         <>
             <div className="space-y-6">
-                {Object.entries(agentsByRole).map(([role, roleAgents]) => (
-                    <div key={role}>
-                        <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
-                            <Badge variant="outline" className={ROLE_COLORS[role as AgentRole]}>
-                                {ROLE_LABELS[role as AgentRole]}
-                            </Badge>
-                            <span className="text-xs">({roleAgents.length})</span>
-                        </h3>
-                        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                            {roleAgents.map((agent) => (
-                                <Card key={agent.id} className="relative">
+                {Object.entries(agentsByRole).map(([role, roleAgents]) => {
+                    const allSelected = roleAgents.every(a => selectedAgentIds.includes(a.id));
+                    const someSelected = roleAgents.some(a => selectedAgentIds.includes(a.id));
+                    
+                    return (
+                        <div key={role}>
+                            <div className="flex items-center gap-2 mb-3">
+                                <Checkbox
+                                    checked={allSelected}
+                                    onCheckedChange={() => handleSelectAllInGroup(roleAgents)}
+                                    aria-label={`Select all ${role} agents`}
+                                />
+                                <h3 className="text-sm font-medium text-muted-foreground flex items-center gap-2 flex-1">
+                                    <Badge variant="outline" className={ROLE_COLORS[role as AgentRole]}>
+                                        {ROLE_LABELS[role as AgentRole]}
+                                    </Badge>
+                                    <span className="text-xs">({roleAgents.length})</span>
+                                </h3>
+                            </div>
+                            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                                {roleAgents.map((agent) => (
+                                    <Card
+                                        key={agent.id}
+                                        className={`relative cursor-pointer transition-all ${
+                                            selectedAgentIds.includes(agent.id) ? 'ring-2 ring-primary bg-primary/5' : ''
+                                        }`}
+                                        onClick={() => handleToggleSelect(agent.id)}
+                                    >
                                     <CardHeader className="pb-3">
                                         <div className="flex items-start justify-between">
-                                            <div className="space-y-1">
-                                                <CardTitle className="text-base flex items-center gap-2">
-                                                    {agent.name}
-                                                    {agent.isSystem && (
-                                                        <Badge variant="secondary" className="text-xs">
-                                                            System
-                                                        </Badge>
-                                                    )}
-                                                </CardTitle>
+                                            <div
+                                                className="space-y-1 flex-1"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <div className="flex items-center gap-2">
+                                                    <Checkbox
+                                                        checked={selectedAgentIds.includes(agent.id)}
+                                                        onCheckedChange={() => handleToggleSelect(agent.id)}
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        aria-label={`Select ${agent.name}`}
+                                                    />
+                                                    <CardTitle className="text-base flex items-center gap-2">
+                                                        {agent.name}
+                                                        {agent.isSystem && (
+                                                            <Badge variant="secondary" className="text-xs">
+                                                                System
+                                                            </Badge>
+                                                        )}
+                                                    </CardTitle>
+                                                </div>
                                                 {agent.description && (
                                                     <CardDescription className="text-xs line-clamp-2">
                                                         {agent.description}
                                                     </CardDescription>
                                                 )}
                                             </div>
-                                            <DropdownMenu>
+                                            <div onClick={(e) => e.stopPropagation()}>
+                                                <DropdownMenu>
                                                 <DropdownMenuTrigger asChild>
                                                     <Button variant="ghost" size="icon" className="h-8 w-8">
                                                         <MoreVertical className="h-4 w-4" />
@@ -179,6 +227,7 @@ export function AgentPresetList({ agents, onEdit }: AgentPresetListProps) {
                                                     )}
                                                 </DropdownMenuContent>
                                             </DropdownMenu>
+                                            </div>
                                         </div>
                                     </CardHeader>
                                     <CardContent>
@@ -203,7 +252,8 @@ export function AgentPresetList({ agents, onEdit }: AgentPresetListProps) {
                             ))}
                         </div>
                     </div>
-                ))}
+                    );
+                })}
             </div>
 
             <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>

--- a/src/features/agents/components/AgentPresetList.tsx
+++ b/src/features/agents/components/AgentPresetList.tsx
@@ -40,6 +40,8 @@ const ROLE_COLORS: Record<AgentRole, string> = {
     style_extractor: 'bg-rose-500/10 text-rose-500 border-rose-500/20',
     scenebeat_generator: 'bg-teal-500/10 text-teal-500 border-teal-500/20',
     refusal_checker: 'bg-red-500/10 text-red-500 border-red-500/20',
+    chapter_reviewer: 'bg-violet-500/10 text-violet-500 border-violet-500/20',
+    chapter_editor: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/20',
     custom: 'bg-gray-500/10 text-gray-500 border-gray-500/20',
 };
 
@@ -55,6 +57,8 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     style_extractor: 'Style Extractor',
     scenebeat_generator: 'Scene Beat Generator',
     refusal_checker: 'Refusal Checker',
+    chapter_reviewer: 'Chapter Reviewer',
+    chapter_editor: 'Chapter Editor',
     custom: 'Custom',
 };
 

--- a/src/features/agents/components/AgentsManager.tsx
+++ b/src/features/agents/components/AgentsManager.tsx
@@ -1,14 +1,27 @@
 import { useState, useEffect } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { Plus, Bot, GitBranch, History } from 'lucide-react';
+import { Plus, Bot, GitBranch, History, RotateCcw } from 'lucide-react';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'react-toastify';
 import { useAgentsStore } from '../stores/useAgentsStore';
 import { useStoryContext } from '@/features/stories/context/StoryContext';
 import { AgentPresetList } from './AgentPresetList';
 import { AgentPresetForm } from './AgentPresetForm';
 import { PipelinePresetList } from './PipelinePresetList';
 import { PipelinePresetForm } from './PipelinePresetForm';
-import type { AgentPreset, PipelinePreset } from '@/types/story';
+import { BulkUpdatePanel } from '@/components/BulkUpdatePanel';
+import type { AgentPreset, PipelinePreset, AllowedModel } from '@/types/story';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 export function AgentsManager() {
@@ -18,6 +31,8 @@ export function AgentsManager() {
         pipelinePresets,
         loadAgentPresets,
         loadPipelinePresets,
+        resetSystemDefaults,
+        bulkUpdateAgentModel,
         isLoadingPresets,
         isLoadingPipelines,
     } = useAgentsStore();
@@ -27,11 +42,37 @@ export function AgentsManager() {
     const [showPipelineForm, setShowPipelineForm] = useState(false);
     const [editingAgent, setEditingAgent] = useState<AgentPreset | undefined>();
     const [editingPipeline, setEditingPipeline] = useState<PipelinePreset | undefined>();
+    const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
+    const [showBulkUpdate, setShowBulkUpdate] = useState(false);
+    const [isApplyingBulkUpdate, setIsApplyingBulkUpdate] = useState(false);
 
     useEffect(() => {
         loadAgentPresets(currentStoryId);
         loadPipelinePresets(currentStoryId);
     }, [currentStoryId, loadAgentPresets, loadPipelinePresets]);
+
+    const handleResetDefaults = async () => {
+        try {
+            await resetSystemDefaults(currentStoryId);
+            toast.success('System agents and pipelines restored to defaults');
+        } catch (err) {
+            console.error('[AgentsManager] Reset failed:', err);
+            toast.error('Failed to reset defaults — check the console for details');
+        }
+    };
+
+    const handleBulkUpdateModel = async (model: AllowedModel) => {
+        if (selectedAgentIds.length === 0) return;
+        
+        setIsApplyingBulkUpdate(true);
+        try {
+            await bulkUpdateAgentModel(selectedAgentIds, model);
+            setSelectedAgentIds([]);
+            setShowBulkUpdate(false);
+        } finally {
+            setIsApplyingBulkUpdate(false);
+        }
+    };
 
     const handleNewAgent = (e?: React.MouseEvent) => {
         e?.preventDefault();
@@ -105,6 +146,30 @@ export function AgentsManager() {
                             Configure AI agents and pipelines for multi-step generation
                         </p>
                     </div>
+                    <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                            <Button variant="outline" size="sm" className="flex items-center gap-2">
+                                <RotateCcw className="h-4 w-4" />
+                                Reset Defaults
+                            </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                            <AlertDialogHeader>
+                                <AlertDialogTitle>Reset system agents &amp; pipelines?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    This will recreate any missing system agents and force-update all system
+                                    pipeline definitions to their defaults. Your custom agents and pipelines
+                                    will not be affected.
+                                </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction onClick={handleResetDefaults}>
+                                    Reset
+                                </AlertDialogAction>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialog>
                 </div>
             </div>
 
@@ -149,6 +214,13 @@ export function AgentsManager() {
                             <AgentPresetList
                                 agents={agentPresets}
                                 onEdit={handleEditAgent}
+                                selectedAgentIds={selectedAgentIds}
+                                onSelectionChange={(ids) => {
+                                    setSelectedAgentIds(ids);
+                                    if (ids.length > 0) {
+                                        setShowBulkUpdate(true);
+                                    }
+                                }}
                             />
                         )}
                     </TabsContent>
@@ -193,6 +265,17 @@ export function AgentsManager() {
                     </TabsContent>
                 </ScrollArea>
             </Tabs>
+            
+            <BulkUpdatePanel
+                selectedCount={selectedAgentIds.length}
+                isVisible={showBulkUpdate && activeTab === 'agents'}
+                onClose={() => {
+                    setShowBulkUpdate(false);
+                    setSelectedAgentIds([]);
+                }}
+                onApplyModel={handleBulkUpdateModel}
+                isApplying={isApplyingBulkUpdate}
+            />
         </div>
     );
 }

--- a/src/features/agents/components/PipelinePresetForm.tsx
+++ b/src/features/agents/components/PipelinePresetForm.tsx
@@ -36,6 +36,8 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     style_extractor: 'Style Extractor',
     scenebeat_generator: 'Scene Beat Generator',
     refusal_checker: 'Refusal Checker',
+    chapter_reviewer: 'Chapter Reviewer',
+    chapter_editor: 'Chapter Editor',
     custom: 'Custom',
 };
 

--- a/src/features/agents/components/PipelinePresetList.tsx
+++ b/src/features/agents/components/PipelinePresetList.tsx
@@ -40,6 +40,8 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     style_extractor: 'Style Extractor',
     scenebeat_generator: 'Scene Beat Generator',
     refusal_checker: 'Refusal Checker',
+    chapter_reviewer: 'Chapter Reviewer',
+    chapter_editor: 'Chapter Editor',
     custom: 'Custom',
 };
 

--- a/src/features/agents/services/agentSeeder.ts
+++ b/src/features/agents/services/agentSeeder.ts
@@ -84,13 +84,13 @@ const CONTEXT_CONFIGS: Record<string, AgentContextConfig> = {
         includePovInfo: false,
     },
     chapter_reviewer: {
-        lorebookMode: 'all',
+        lorebookMode: 'matched',
         previousWordsMode: 'full',
         includeChapterSummary: false,
         includePovInfo: true,
     },
     chapter_editor: {
-        lorebookMode: 'all',
+        lorebookMode: 'matched',
         previousWordsMode: 'full',
         includeChapterSummary: false,
         includePovInfo: true,
@@ -370,6 +370,8 @@ If no specific instructions are given, perform a thorough editorial pass:
 - Improve transitions between scenes and paragraphs
 - Strengthen the opening and closing lines
 
+CRITICAL LENGTH RULE: Your output MUST be approximately the same length as the input chapter (within ±10%). Do not summarise, truncate, or significantly expand the text. Every scene that exists in the original must exist in the edited version.
+
 Return ONLY the edited chapter text. Do not include commentary, preamble, explanations, or headings. Output the full chapter from start to finish.`,
         temperature: 0.7,
         maxTokens: 8192,
@@ -522,6 +524,22 @@ export async function seedSystemAgents(force: boolean = false): Promise<void> {
     try {
         console.log(`[AgentSeeder] Checking for system agents... (force update: ${force})`);
 
+        // When force=true, wipe all existing system agents and pipelines so everything
+        // is recreated from the current SYSTEM_AGENT_PRESETS definitions.
+        if (force) {
+            console.log('[AgentSeeder] Force mode: deleting all existing system agents and pipelines...');
+            const systemAgentIds = await db.agentPresets
+                .filter(a => a.isSystem === true)
+                .primaryKeys();
+            await db.agentPresets.bulkDelete(systemAgentIds as string[]);
+
+            const systemPipelineIds = await db.pipelinePresets
+                .filter(p => p.isSystem === true)
+                .primaryKeys();
+            await db.pipelinePresets.bulkDelete(systemPipelineIds as string[]);
+            console.log(`[AgentSeeder] Deleted ${systemAgentIds.length} agents and ${systemPipelineIds.length} pipelines.`);
+        }
+
         // Get existing system agents and pipelines by name for uniqueness check
         const existingAgents = await db.agentPresets
             .filter(a => a.isSystem === true)
@@ -540,12 +558,9 @@ export async function seedSystemAgents(force: boolean = false): Promise<void> {
         }, {} as Record<AgentRole, AgentPreset>);
 
         // Create system agent presets (only if not already exists by name)
-        // Note: We generally don't force update agents to avoid overwriting user customizations to system prompts
         const createdAgents: AgentPreset[] = [];
         for (const preset of SYSTEM_AGENT_PRESETS) {
             if (existingAgentNames.has(preset.name)) {
-                // If force is true, we could update agents here, but it's risky.
-                // For now, we assume agent definitions act as templates that users might tweak.
                 continue;
             }
 

--- a/src/features/agents/services/agentSeeder.ts
+++ b/src/features/agents/services/agentSeeder.ts
@@ -83,6 +83,18 @@ const CONTEXT_CONFIGS: Record<string, AgentContextConfig> = {
         includeChapterSummary: false,
         includePovInfo: false,
     },
+    chapter_reviewer: {
+        lorebookMode: 'all',
+        previousWordsMode: 'full',
+        includeChapterSummary: false,
+        includePovInfo: true,
+    },
+    chapter_editor: {
+        lorebookMode: 'all',
+        previousWordsMode: 'full',
+        includeChapterSummary: false,
+        includePovInfo: true,
+    },
 };
 
 // System agent presets with template variables
@@ -316,6 +328,55 @@ Response format:
         storyId: null,
         contextConfig: CONTEXT_CONFIGS.refusal_checker,
     },
+    {
+        name: 'System Chapter Reviewer',
+        description: 'Reviews an entire chapter for prose quality, consistency, pacing, and provides editorial feedback.',
+        role: 'chapter_reviewer',
+        model: DEFAULT_MODELS.creative,
+        systemPrompt: `You are an expert fiction editor and literary critic. Your job is to review a complete chapter and provide detailed, constructive feedback.
+
+Review the chapter across these dimensions:
+
+1. **Prose Quality**: Sentence variety, word choice, show vs. tell balance, rhythm and flow
+2. **Character Consistency**: Are characters acting true to their established traits? Is dialogue authentic?
+3. **Pacing**: Does the chapter move at an appropriate speed? Are there slow or rushed sections?
+4. **Scene Structure**: Is there a clear opening, middle, and payoff? Does tension build effectively?
+5. **Lore & Continuity**: Any contradictions with established world-building or character facts?
+6. **Dialogue**: Natural? Distinct character voices? Subtext present where appropriate?
+7. **Emotional Impact**: Does the chapter land emotionally? Are the stakes clear and felt?
+8. **Strengths**: What works well and should be preserved?
+9. **Suggestions**: Specific, actionable improvements with brief examples where helpful.
+
+Be honest but constructive. Lead with what works, then address what can be improved. Be specific — generic praise or criticism is not useful.`,
+        temperature: 0.4,
+        maxTokens: 3000,
+        isSystem: true,
+        storyId: null,
+        contextConfig: CONTEXT_CONFIGS.chapter_reviewer,
+    },
+    {
+        name: 'System Chapter Editor',
+        description: 'Rewrites and edits an entire chapter based on instructions. Uses high token limit for full-chapter output.',
+        role: 'chapter_editor',
+        model: DEFAULT_MODELS.creative,
+        systemPrompt: `You are a professional fiction editor. You will receive the full text of a chapter and editing instructions (if any). Your task is to rewrite and edit the chapter while preserving the author's voice and intent.
+
+If no specific instructions are given, perform a thorough editorial pass:
+- Improve sentence variety and pacing
+- Tighten prose (remove redundancy and unnecessary words)
+- Enhance show vs. tell throughout
+- Polish dialogue for naturalness and distinct character voice
+- Fix pacing and tension issues
+- Improve transitions between scenes and paragraphs
+- Strengthen the opening and closing lines
+
+Return ONLY the edited chapter text. Do not include commentary, preamble, explanations, or headings. Output the full chapter from start to finish.`,
+        temperature: 0.7,
+        maxTokens: 8192,
+        isSystem: true,
+        storyId: null,
+        contextConfig: CONTEXT_CONFIGS.chapter_editor,
+    },
 ];
 
 // System pipeline presets
@@ -407,6 +468,37 @@ const SYSTEM_PIPELINE_PRESETS: {
                 streamOutput: true,
                 pushPrompt: `Your previous response was flagged as a refusal. You MUST write the creative prose as instructed. Do not refuse, apologize, or provide meta-commentary. Write the story content directly, continuing from where the previous context left off.`,
             },
+        ],
+    },
+    {
+        name: 'Chapter Review',
+        description: 'Reviews an entire chapter for prose quality, consistency, pacing, and provides detailed editorial feedback.',
+        agentRoles: [
+            { role: 'chapter_reviewer', streamOutput: true },
+        ],
+    },
+    {
+        name: 'Chapter Deep Review',
+        description: 'Reviews a chapter then follows up with a lore and continuity check.',
+        agentRoles: [
+            { role: 'chapter_reviewer', streamOutput: true },
+            { role: 'lore_judge' },
+            { role: 'continuity_checker' },
+        ],
+    },
+    {
+        name: 'Chapter Edit',
+        description: 'Rewrites and edits the full chapter in a single pass. Best for general editorial polish.',
+        agentRoles: [
+            { role: 'chapter_editor', streamOutput: true },
+        ],
+    },
+    {
+        name: 'Chapter Review then Edit',
+        description: 'Reviews the chapter first, then produces a fully edited version addressing the identified issues.',
+        agentRoles: [
+            { role: 'chapter_reviewer' },
+            { role: 'chapter_editor', streamOutput: true },
         ],
     },
 ];

--- a/src/features/agents/stores/useAgentsStore.ts
+++ b/src/features/agents/stores/useAgentsStore.ts
@@ -114,6 +114,17 @@ Review the chapter across the following dimensions:
 
 Be honest but constructive. Lead with what works well, then address what can be improved.`,
 
+    chapter_editor: `You are an expert fiction editor. Your job is to rewrite and improve a chapter based on the review feedback provided.
+
+Focus on:
+1. **Prose polishing**: Improve sentence rhythm, word choice, and flow
+2. **Show vs tell**: Convert telling passages into vivid, sensory scenes
+3. **Dialogue**: Sharpen character voices and remove on-the-nose exchanges
+4. **Pacing**: Trim slow sections, expand rushed moments
+5. **Consistency**: Ensure character behaviour and lore details are accurate
+
+Preserve the author's voice and the core story beats. Return the full rewritten chapter text.`,
+
     custom: `You are a helpful AI assistant. Follow the instructions provided and assist with the writing task.`
 };
 
@@ -151,8 +162,14 @@ interface AgentsState {
     savePipelineExecution: (execution: Omit<PipelineExecution, 'id' | 'createdAt'>) => Promise<string>;
     deletePipelineExecution: (id: string) => Promise<void>;
 
+    // Bulk Operations
+    bulkUpdateAgentPresets: (ids: string[], data: Partial<AgentPreset>) => Promise<void>;
+    bulkUpdateAgentModel: (ids: string[], model: AllowedModel) => Promise<void>;
+    bulkUpdatePipelinePresets: (ids: string[], data: Partial<PipelinePreset>) => Promise<void>;
+
     // Utility
     createDefaultAgentPreset: (role: AgentRole, model: AllowedModel, storyId?: string | null) => Promise<AgentPreset>;
+    resetSystemDefaults: (storyId?: string | null) => Promise<void>;
 }
 
 export const useAgentsStore = create<AgentsState>((set, get) => ({
@@ -332,6 +349,19 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
     },
 
     // Utility
+    resetSystemDefaults: async (storyId?: string | null) => {
+        set({ isLoadingPresets: true, isLoadingPipelines: true });
+        try {
+            await seedSystemAgents(true);
+            await get().loadAgentPresets(storyId);
+            await get().loadPipelinePresets(storyId);
+        } catch (error) {
+            console.error('[AgentsStore] Failed to reset system defaults:', error);
+            set({ isLoadingPresets: false, isLoadingPipelines: false });
+            throw error;
+        }
+    },
+
     createDefaultAgentPreset: async (role, model, storyId = null) => {
         const roleNames: Record<AgentRole, string> = {
             summarizer: 'Summarizer',
@@ -362,5 +392,41 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
         };
 
         return get().createAgentPreset(preset);
+    },
+
+    // Bulk update multiple agents with partial data
+    bulkUpdateAgentPresets: async (ids, data) => {
+        await db.agentPresets.bulkUpdate(
+            ids.map(id => ({ key: id, changes: data }))
+        );
+        set(state => ({
+            agentPresets: state.agentPresets.map(p =>
+                ids.includes(p.id) ? { ...p, ...data } : p
+            )
+        }));
+    },
+
+    // Bulk update agent model
+    bulkUpdateAgentModel: async (ids, model) => {
+        await db.agentPresets.bulkUpdate(
+            ids.map(id => ({ key: id, changes: { model } }))
+        );
+        set(state => ({
+            agentPresets: state.agentPresets.map(p =>
+                ids.includes(p.id) ? { ...p, model } : p
+            )
+        }));
+    },
+
+    // Bulk update multiple pipelines with partial data
+    bulkUpdatePipelinePresets: async (ids, data) => {
+        await db.pipelinePresets.bulkUpdate(
+            ids.map(id => ({ key: id, changes: data }))
+        );
+        set(state => ({
+            pipelinePresets: state.pipelinePresets.map(p =>
+                ids.includes(p.id) ? { ...p, ...data } : p
+            )
+        }));
     },
 }));

--- a/src/features/agents/stores/useAgentsStore.ts
+++ b/src/features/agents/stores/useAgentsStore.ts
@@ -97,7 +97,23 @@ Output a concise style guide that another AI could use to mimic this writing sty
     Response format:
     - If the text contains a refusal or avoidance: respond with exactly: REFUSAL_DETECTED: [brief description of what was refused]
     - If the text is genuine creative prose (even if imperfect): respond with exactly: CONTENT_OK`,
-    
+
+    chapter_reviewer: `You are an expert fiction editor and literary critic. Your job is to review a full chapter and provide detailed, constructive feedback.
+
+Review the chapter across the following dimensions:
+
+1. **Prose Quality**: Sentence variety, word choice, show vs. tell balance, rhythm and flow
+2. **Character Consistency**: Are characters acting true to their established traits? Is dialogue authentic?
+3. **Pacing**: Does the chapter move at an appropriate speed? Are there slow or rushed sections?
+4. **Scene Structure**: Is there a clear opening, middle, and payoff? Does tension build effectively?
+5. **Lore & Continuity**: Any contradictions with established world-building or character facts?
+6. **Dialogue**: Natural? Distinct character voices? Subtext present where appropriate?
+7. **Emotional Impact**: Does the chapter land emotionally? Does the reader feel connected to the stakes?
+8. **Strengths**: What works well and should be preserved?
+9. **Suggestions**: Specific, actionable improvements with brief examples where helpful.
+
+Be honest but constructive. Lead with what works well, then address what can be improved.`,
+
     custom: `You are a helpful AI assistant. Follow the instructions provided and assist with the writing task.`
 };
 
@@ -329,6 +345,8 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
             style_extractor: 'Style Extractor',
             scenebeat_generator: 'Scene Beat Generator',
             refusal_checker: 'Refusal Checker',
+            chapter_reviewer: 'Chapter Reviewer',
+            chapter_editor: 'Chapter Editor',
             custom: 'Custom Agent'
         };
 

--- a/src/features/ai/stores/useAIStore.ts
+++ b/src/features/ai/stores/useAIStore.ts
@@ -60,6 +60,9 @@ interface AIState {
     abortGeneration: () => void;
 }
 
+// Singleton init promise — prevents concurrent calls from duplicating work
+let _initPromise: Promise<void> | null = null;
+
 export const useAIStore = create<AIState>((set, get) => ({
     settings: null,
     isInitialized: false,
@@ -68,22 +71,33 @@ export const useAIStore = create<AIState>((set, get) => ({
     favoriteModelIds: [],
 
     initialize: async () => {
-        set({ isLoading: true, error: null });
-        try {
-            await aiService.initialize();
-            const settings = await db.aiSettings.toArray();
-            set({
-                settings: settings[0] || null,
-                favoriteModelIds: settings[0]?.favoriteModelIds || [],
-                isInitialized: true,
-                isLoading: false
-            });
-        } catch (error) {
-            set({
-                error: error instanceof Error ? error.message : 'Failed to initialize AI',
-                isLoading: false
-            });
-        }
+        // Already initialized — nothing to do
+        if (get().isInitialized) return;
+        // A concurrent init is in flight — share it
+        if (_initPromise) return _initPromise;
+
+        _initPromise = (async () => {
+            set({ isLoading: true, error: null });
+            try {
+                await aiService.initialize();
+                const settings = await db.aiSettings.toArray();
+                set({
+                    settings: settings[0] || null,
+                    favoriteModelIds: settings[0]?.favoriteModelIds || [],
+                    isInitialized: true,
+                    isLoading: false
+                });
+            } catch (error) {
+                set({
+                    error: error instanceof Error ? error.message : 'Failed to initialize AI',
+                    isLoading: false
+                });
+            } finally {
+                _initPromise = null;
+            }
+        })();
+
+        return _initPromise;
     },
 
     getAvailableModels: async (provider?: AIProvider, forceRefresh: boolean = false) => {
@@ -176,7 +190,8 @@ export const useAIStore = create<AIState>((set, get) => ({
                     top_p,
                     top_k,
                     repetition_penalty,
-                    min_p
+                    min_p,
+                    selectedModel.id
                 );
             case 'openai':
                 return aiService.generateWithOpenAI(
@@ -259,7 +274,8 @@ export const useAIStore = create<AIState>((set, get) => ({
                     top_p,
                     top_k,
                     repetition_penalty,
-                    min_p
+                    min_p,
+                    selectedModel.id
                 );
             case 'openai':
                 return aiService.generateWithOpenAI(

--- a/src/features/chapters/components/AIEditorialPanel.tsx
+++ b/src/features/chapters/components/AIEditorialPanel.tsx
@@ -5,13 +5,14 @@
  *   Edit   — produces a fully rewritten chapter using the chapter_editor role
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ClipboardCopy, FileEdit, FileSearch, Loader2, RotateCcw, SquareX } from 'lucide-react';
+import { ClipboardCopy, FileEdit, FileSearch, Loader2, Maximize2, Minimize2, RotateCcw, SquareX } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { ChapterReviewPanel } from '@/features/chapters/components/ChapterReviewPanel';
 import { useStoryContext } from '@/features/stories/context/StoryContext';
 import { useChapterStore } from '@/features/chapters/stores/useChapterStore';
@@ -20,10 +21,42 @@ import { useAgenticGeneration } from '@/features/agents/hooks/useAgenticGenerati
 import type { PipelinePreset } from '@/types/story';
 import { toast } from 'react-toastify';
 
+function wordCount(text: string): number {
+    return text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+}
+
+function WordCountBadge({ original, edited }: { original: number; edited: number }) {
+    if (original === 0) return null;
+    const pct = Math.round(((edited - original) / original) * 100);
+    const inRange = Math.abs(pct) <= 10;
+    return (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>Original: <strong>{original.toLocaleString()}</strong> words</span>
+            <span>·</span>
+            <span>Edited: <strong>{edited.toLocaleString()}</strong> words</span>
+            {edited > 0 && (
+                <Badge variant={inRange ? 'secondary' : 'destructive'} className="text-xs">
+                    {pct >= 0 ? '+' : ''}{pct}%
+                </Badge>
+            )}
+        </div>
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Inner component: chapter edit mode
 // ---------------------------------------------------------------------------
-function ChapterEditContent() {
+function ChapterEditContent({
+    editInstructions,
+    setEditInstructions,
+    isExpanded,
+    onExpandChange,
+}: {
+    editInstructions: string;
+    setEditInstructions: (v: string) => void;
+    isExpanded: boolean;
+    onExpandChange: (v: boolean) => void;
+}) {
     const { currentChapterId } = useStoryContext();
     const { currentChapter, getChapterPlainText } = useChapterStore();
     const { entries: lorebookEntries } = useLorebookStore();
@@ -31,7 +64,6 @@ function ChapterEditContent() {
     const {
         isGenerating,
         currentAgentName,
-        stepResults,
         generateWithPipeline,
         abortGeneration,
         getAvailablePipelines,
@@ -39,11 +71,12 @@ function ChapterEditContent() {
 
     const [pipelines, setPipelines] = useState<PipelinePreset[]>([]);
     const [selectedPipelineId, setSelectedPipelineId] = useState<string>('');
-    const [editInstructions, setEditInstructions] = useState('');
     const [streamedOutput, setStreamedOutput] = useState('');
     const [finalOutput, setFinalOutput] = useState('');
+    const [originalText, setOriginalText] = useState('');
     const [hasRun, setHasRun] = useState(false);
     const outputRef = useRef<HTMLDivElement>(null);
+    const originalRef = useRef<HTMLDivElement>(null);
 
     // Load pipelines — prefer edit-oriented ones
     useEffect(() => {
@@ -90,6 +123,7 @@ function ChapterEditContent() {
 
         setStreamedOutput('');
         setFinalOutput('');
+        setOriginalText(chapterText);
         setHasRun(true);
 
         await generateWithPipeline(
@@ -139,11 +173,156 @@ function ChapterEditContent() {
     const handleReset = () => {
         setStreamedOutput('');
         setFinalOutput('');
+        setOriginalText('');
         setHasRun(false);
     };
 
     const displayOutput = finalOutput || streamedOutput;
+    const origWords = wordCount(originalText);
+    const editedWords = wordCount(displayOutput);
 
+    // ── POST-RUN: expanded = split pane, narrow = edited only ──────────────
+    if (hasRun) {
+        const controlsBar = (
+            <div className="flex flex-wrap items-end gap-2">
+                <div className="flex-1 min-w-[140px] space-y-1">
+                    <Label htmlFor="chapter-edit-pipeline" className="text-xs">Pipeline</Label>
+                    <Select value={selectedPipelineId} onValueChange={setSelectedPipelineId} disabled={isGenerating}>
+                        <SelectTrigger id="chapter-edit-pipeline" className="h-8 text-xs">
+                            <SelectValue placeholder="Select a pipeline…" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {pipelines.map((p) => (
+                                <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <div className="flex-[2] min-w-[160px] space-y-1">
+                    <Label htmlFor="chapter-edit-instructions" className="text-xs">Instructions</Label>
+                    <Textarea
+                        id="chapter-edit-instructions"
+                        placeholder="e.g. Tighten the pacing…"
+                        rows={1}
+                        value={editInstructions}
+                        onChange={(e) => setEditInstructions(e.target.value)}
+                        disabled={isGenerating}
+                        className="resize-y text-xs min-h-[32px] py-1"
+                    />
+                </div>
+
+                <div className="flex items-center gap-1.5 flex-shrink-0">
+                    {!isGenerating ? (
+                        <Button onClick={handleRun} disabled={!selectedPipelineId || !currentChapterId} size="sm">
+                            <FileEdit className="h-3.5 w-3.5 mr-1" />
+                            Edit Again
+                        </Button>
+                    ) : (
+                        <Button variant="destructive" onClick={abortGeneration} size="sm">
+                            <SquareX className="h-3.5 w-3.5 mr-1" />
+                            Stop
+                        </Button>
+                    )}
+                    <Button variant="outline" size="icon" className="h-8 w-8" onClick={handleReset} title="Clear">
+                        <RotateCcw className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => onExpandChange(!isExpanded)}
+                        title={isExpanded ? 'Collapse' : 'Expand to compare'}
+                    >
+                        {isExpanded
+                            ? <Minimize2 className="h-3.5 w-3.5" />
+                            : <Maximize2 className="h-3.5 w-3.5" />}
+                    </Button>
+                </div>
+            </div>
+        );
+
+        const statusBar = (
+            <div className="flex items-center justify-between">
+                <WordCountBadge original={origWords} edited={editedWords} />
+                {isGenerating && (
+                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        {currentAgentName ? `Running: ${currentAgentName}` : 'Starting…'}
+                    </div>
+                )}
+                {!isGenerating && displayOutput && (
+                    <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={handleCopy}>
+                        <ClipboardCopy className="h-3 w-3" />
+                        Copy
+                    </Button>
+                )}
+            </div>
+        );
+
+        if (isExpanded) {
+            // ── Wide: side-by-side panes ────────────────────────────────
+            return (
+                <div className="flex flex-col gap-3 pt-2">
+                    {controlsBar}
+                    {statusBar}
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Original</span>
+                            <div
+                                ref={originalRef}
+                                className="rounded-md border bg-muted/20 p-3 text-sm whitespace-pre-wrap overflow-y-auto leading-relaxed"
+                                style={{ height: 'calc(100vh - 300px)' }}
+                            >
+                                {originalText || <span className="text-muted-foreground italic">No text captured</span>}
+                            </div>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Edited</span>
+                            <div
+                                ref={outputRef}
+                                className="rounded-md border bg-background p-3 text-sm whitespace-pre-wrap overflow-y-auto leading-relaxed"
+                                style={{ height: 'calc(100vh - 300px)' }}
+                            >
+                                {displayOutput || <span className="text-muted-foreground italic">Generating…</span>}
+                                {isGenerating && <span className="inline-block w-1 h-4 bg-primary ml-0.5 animate-pulse" />}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+        // ── Narrow: edited output only ──────────────────────────────────
+        return (
+            <div className="flex flex-col gap-3 pt-2">
+                {controlsBar}
+                {statusBar}
+                <div className="flex flex-col gap-1">
+                    <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Edited</span>
+                    </div>
+                    <div
+                        ref={outputRef}
+                        className="rounded-md border bg-background p-3 text-sm whitespace-pre-wrap overflow-y-auto leading-relaxed"
+                        style={{ height: 'calc(100vh - 320px)' }}
+                    >
+                        {displayOutput || <span className="text-muted-foreground italic">Generating edited chapter…</span>}
+                        {isGenerating && <span className="inline-block w-1 h-4 bg-primary ml-0.5 animate-pulse" />}
+                    </div>
+                </div>
+                {!isGenerating && finalOutput && (
+                    <Alert className="py-2">
+                        <AlertDescription className="text-xs">
+                            Click <Maximize2 className="inline h-3 w-3" /> to compare side-by-side, or Copy and paste into the editor.
+                        </AlertDescription>
+                    </Alert>
+                )}
+            </div>
+        );
+    }
+
+    // ── Initial state: standard single-column controls ──────────────────────
     return (
         <div className="flex flex-col gap-4 pt-2">
             {/* Pipeline selector */}
@@ -178,7 +357,7 @@ function ChapterEditContent() {
                     value={editInstructions}
                     onChange={(e) => setEditInstructions(e.target.value)}
                     disabled={isGenerating}
-                    className="resize-none text-sm"
+                    className="resize-y text-sm"
                 />
                 <p className="text-xs text-muted-foreground">
                     Leave blank for a general editorial pass.
@@ -187,82 +366,15 @@ function ChapterEditContent() {
 
             {/* Action buttons */}
             <div className="flex items-center gap-2">
-                {!isGenerating ? (
-                    <Button
-                        onClick={handleRun}
-                        disabled={!selectedPipelineId || !currentChapterId}
-                        className="flex-1"
-                    >
-                        <FileEdit className="h-4 w-4 mr-2" />
-                        {hasRun ? 'Edit Again' : 'Edit Chapter'}
-                    </Button>
-                ) : (
-                    <Button variant="destructive" onClick={abortGeneration} className="flex-1">
-                        <SquareX className="h-4 w-4 mr-2" />
-                        Stop
-                    </Button>
-                )}
-                {hasRun && !isGenerating && (
-                    <Button variant="outline" size="icon" onClick={handleReset} title="Clear results">
-                        <RotateCcw className="h-4 w-4" />
-                    </Button>
-                )}
+                <Button
+                    onClick={handleRun}
+                    disabled={!selectedPipelineId || !currentChapterId}
+                    className="flex-1"
+                >
+                    <FileEdit className="h-4 w-4 mr-2" />
+                    Edit Chapter
+                </Button>
             </div>
-
-            {/* Progress indicator */}
-            {isGenerating && (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span>{currentAgentName ? `Running: ${currentAgentName}` : 'Starting…'}</span>
-                </div>
-            )}
-
-            {/* Output */}
-            {(displayOutput || isGenerating) && (
-                <div className="space-y-2">
-                    {/* Instruction notice */}
-                    {(finalOutput || (!isGenerating && displayOutput)) && (
-                        <Alert>
-                            <AlertDescription className="text-xs">
-                                This is the AI-edited chapter. Copy it and paste it into the editor to apply the changes.
-                            </AlertDescription>
-                        </Alert>
-                    )}
-
-                    <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium">Edited Chapter</span>
-                        {displayOutput && (
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-7 gap-1 text-xs"
-                                onClick={handleCopy}
-                            >
-                                <ClipboardCopy className="h-3 w-3" />
-                                Copy All
-                            </Button>
-                        )}
-                    </div>
-
-                    <div
-                        ref={outputRef}
-                        className="rounded-md border bg-muted/30 p-3 text-sm whitespace-pre-wrap max-h-[55vh] overflow-y-auto leading-relaxed"
-                    >
-                        {displayOutput || (
-                            <span className="text-muted-foreground italic">Generating edited chapter…</span>
-                        )}
-                        {isGenerating && (
-                            <span className="inline-block w-1 h-4 bg-primary ml-0.5 animate-pulse" />
-                        )}
-                    </div>
-
-                    {!isGenerating && stepResults.length > 0 && (
-                        <p className="text-xs text-muted-foreground text-center">
-                            {stepResults.length} agent step{stepResults.length !== 1 ? 's' : ''} completed
-                        </p>
-                    )}
-                </div>
-            )}
         </div>
     );
 }
@@ -270,9 +382,23 @@ function ChapterEditContent() {
 // ---------------------------------------------------------------------------
 // Public export: the outer tabbed panel
 // ---------------------------------------------------------------------------
-export function AIEditorialPanel() {
+export function AIEditorialPanel({
+    isExpanded = false,
+    onExpandChange,
+}: {
+    isExpanded?: boolean;
+    onExpandChange?: (v: boolean) => void;
+}) {
+    const [activeTab, setActiveTab] = useState('review');
+    const [editInstructions, setEditInstructions] = useState('');
+
+    const handleSendToEdit = (reviewText: string) => {
+        setEditInstructions(reviewText);
+        setActiveTab('edit');
+    };
+
     return (
-        <Tabs defaultValue="review" className="w-full">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <TabsList className="w-full">
                 <TabsTrigger value="review" className="flex-1 gap-1.5">
                     <FileSearch className="h-3.5 w-3.5" />
@@ -285,11 +411,16 @@ export function AIEditorialPanel() {
             </TabsList>
 
             <TabsContent value="review" className="mt-3">
-                <ChapterReviewPanel />
+                <ChapterReviewPanel onSendToEdit={handleSendToEdit} />
             </TabsContent>
 
             <TabsContent value="edit" className="mt-3">
-                <ChapterEditContent />
+                <ChapterEditContent
+                    editInstructions={editInstructions}
+                    setEditInstructions={setEditInstructions}
+                    isExpanded={isExpanded}
+                    onExpandChange={onExpandChange ?? (() => {})}
+                />
             </TabsContent>
         </Tabs>
     );

--- a/src/features/chapters/components/AIEditorialPanel.tsx
+++ b/src/features/chapters/components/AIEditorialPanel.tsx
@@ -1,0 +1,296 @@
+/**
+ * AIEditorialPanel — the top-level "AI Editorial" sheet panel.
+ * Provides two modes via tabs:
+ *   Review — editorial feedback on the chapter (uses ChapterReviewPanel)
+ *   Edit   — produces a fully rewritten chapter using the chapter_editor role
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ClipboardCopy, FileEdit, FileSearch, Loader2, RotateCcw, SquareX } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ChapterReviewPanel } from '@/features/chapters/components/ChapterReviewPanel';
+import { useStoryContext } from '@/features/stories/context/StoryContext';
+import { useChapterStore } from '@/features/chapters/stores/useChapterStore';
+import { useLorebookStore } from '@/features/lorebook/stores/useLorebookStore';
+import { useAgenticGeneration } from '@/features/agents/hooks/useAgenticGeneration';
+import type { PipelinePreset } from '@/types/story';
+import { toast } from 'react-toastify';
+
+// ---------------------------------------------------------------------------
+// Inner component: chapter edit mode
+// ---------------------------------------------------------------------------
+function ChapterEditContent() {
+    const { currentChapterId } = useStoryContext();
+    const { currentChapter, getChapterPlainText } = useChapterStore();
+    const { entries: lorebookEntries } = useLorebookStore();
+
+    const {
+        isGenerating,
+        currentAgentName,
+        stepResults,
+        generateWithPipeline,
+        abortGeneration,
+        getAvailablePipelines,
+    } = useAgenticGeneration();
+
+    const [pipelines, setPipelines] = useState<PipelinePreset[]>([]);
+    const [selectedPipelineId, setSelectedPipelineId] = useState<string>('');
+    const [editInstructions, setEditInstructions] = useState('');
+    const [streamedOutput, setStreamedOutput] = useState('');
+    const [finalOutput, setFinalOutput] = useState('');
+    const [hasRun, setHasRun] = useState(false);
+    const outputRef = useRef<HTMLDivElement>(null);
+
+    // Load pipelines — prefer edit-oriented ones
+    useEffect(() => {
+        getAvailablePipelines().then((all) => {
+            setPipelines(all);
+            const editPipeline = all.find(
+                (p) =>
+                    p.name.toLowerCase() === 'chapter edit' ||
+                    p.name.toLowerCase().includes('chapter edit')
+            );
+            if (editPipeline) {
+                setSelectedPipelineId(editPipeline.id);
+            } else if (all.length > 0) {
+                setSelectedPipelineId(all[0].id);
+            }
+        });
+    }, [getAvailablePipelines]);
+
+    // Auto-scroll output as tokens arrive
+    useEffect(() => {
+        if (outputRef.current) {
+            outputRef.current.scrollTop = outputRef.current.scrollHeight;
+        }
+    }, [streamedOutput]);
+
+    const handleRun = useCallback(async () => {
+        if (!currentChapterId || !selectedPipelineId) {
+            toast.error('No chapter or pipeline selected');
+            return;
+        }
+
+        let chapterText = '';
+        try {
+            chapterText = await getChapterPlainText(currentChapterId);
+        } catch {
+            toast.error('Failed to extract chapter text');
+            return;
+        }
+
+        if (!chapterText.trim()) {
+            toast.error('The chapter appears to be empty — nothing to edit');
+            return;
+        }
+
+        setStreamedOutput('');
+        setFinalOutput('');
+        setHasRun(true);
+
+        await generateWithPipeline(
+            selectedPipelineId,
+            {
+                scenebeat: editInstructions,
+                previousWords: chapterText,
+                matchedEntries: lorebookEntries,
+                allEntries: lorebookEntries,
+                povType: currentChapter?.povType,
+                povCharacter: currentChapter?.povCharacter,
+                currentChapter: currentChapter ?? undefined,
+            },
+            {
+                onToken: (token) => {
+                    setStreamedOutput((prev) => prev + token);
+                },
+                onComplete: (r) => {
+                    setFinalOutput(r.finalOutput);
+                    setStreamedOutput('');
+                },
+                onError: (err) => {
+                    toast.error(`Edit failed: ${err.message}`);
+                },
+            }
+        );
+    }, [
+        currentChapterId,
+        selectedPipelineId,
+        editInstructions,
+        getChapterPlainText,
+        lorebookEntries,
+        currentChapter,
+        generateWithPipeline,
+    ]);
+
+    const handleCopy = async () => {
+        const text = finalOutput || streamedOutput;
+        try {
+            await navigator.clipboard.writeText(text);
+            toast.success('Edited chapter copied to clipboard');
+        } catch {
+            toast.error('Failed to copy');
+        }
+    };
+
+    const handleReset = () => {
+        setStreamedOutput('');
+        setFinalOutput('');
+        setHasRun(false);
+    };
+
+    const displayOutput = finalOutput || streamedOutput;
+
+    return (
+        <div className="flex flex-col gap-4 pt-2">
+            {/* Pipeline selector */}
+            <div className="space-y-1">
+                <Label htmlFor="chapter-edit-pipeline">Pipeline</Label>
+                <Select value={selectedPipelineId} onValueChange={setSelectedPipelineId} disabled={isGenerating}>
+                    <SelectTrigger id="chapter-edit-pipeline">
+                        <SelectValue placeholder="Select a pipeline…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {pipelines.map((p) => (
+                            <SelectItem key={p.id} value={p.id}>
+                                {p.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                {pipelines.find((p) => p.id === selectedPipelineId)?.description && (
+                    <p className="text-xs text-muted-foreground">
+                        {pipelines.find((p) => p.id === selectedPipelineId)!.description}
+                    </p>
+                )}
+            </div>
+
+            {/* Optional editing instructions */}
+            <div className="space-y-1">
+                <Label htmlFor="chapter-edit-instructions">Edit Instructions (optional)</Label>
+                <Textarea
+                    id="chapter-edit-instructions"
+                    placeholder="e.g. Tighten the pacing in the middle section. Make the dialogue punchier. Fix the transition into the final scene…"
+                    rows={3}
+                    value={editInstructions}
+                    onChange={(e) => setEditInstructions(e.target.value)}
+                    disabled={isGenerating}
+                    className="resize-none text-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                    Leave blank for a general editorial pass.
+                </p>
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex items-center gap-2">
+                {!isGenerating ? (
+                    <Button
+                        onClick={handleRun}
+                        disabled={!selectedPipelineId || !currentChapterId}
+                        className="flex-1"
+                    >
+                        <FileEdit className="h-4 w-4 mr-2" />
+                        {hasRun ? 'Edit Again' : 'Edit Chapter'}
+                    </Button>
+                ) : (
+                    <Button variant="destructive" onClick={abortGeneration} className="flex-1">
+                        <SquareX className="h-4 w-4 mr-2" />
+                        Stop
+                    </Button>
+                )}
+                {hasRun && !isGenerating && (
+                    <Button variant="outline" size="icon" onClick={handleReset} title="Clear results">
+                        <RotateCcw className="h-4 w-4" />
+                    </Button>
+                )}
+            </div>
+
+            {/* Progress indicator */}
+            {isGenerating && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>{currentAgentName ? `Running: ${currentAgentName}` : 'Starting…'}</span>
+                </div>
+            )}
+
+            {/* Output */}
+            {(displayOutput || isGenerating) && (
+                <div className="space-y-2">
+                    {/* Instruction notice */}
+                    {(finalOutput || (!isGenerating && displayOutput)) && (
+                        <Alert>
+                            <AlertDescription className="text-xs">
+                                This is the AI-edited chapter. Copy it and paste it into the editor to apply the changes.
+                            </AlertDescription>
+                        </Alert>
+                    )}
+
+                    <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium">Edited Chapter</span>
+                        {displayOutput && (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 gap-1 text-xs"
+                                onClick={handleCopy}
+                            >
+                                <ClipboardCopy className="h-3 w-3" />
+                                Copy All
+                            </Button>
+                        )}
+                    </div>
+
+                    <div
+                        ref={outputRef}
+                        className="rounded-md border bg-muted/30 p-3 text-sm whitespace-pre-wrap max-h-[55vh] overflow-y-auto leading-relaxed"
+                    >
+                        {displayOutput || (
+                            <span className="text-muted-foreground italic">Generating edited chapter…</span>
+                        )}
+                        {isGenerating && (
+                            <span className="inline-block w-1 h-4 bg-primary ml-0.5 animate-pulse" />
+                        )}
+                    </div>
+
+                    {!isGenerating && stepResults.length > 0 && (
+                        <p className="text-xs text-muted-foreground text-center">
+                            {stepResults.length} agent step{stepResults.length !== 1 ? 's' : ''} completed
+                        </p>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Public export: the outer tabbed panel
+// ---------------------------------------------------------------------------
+export function AIEditorialPanel() {
+    return (
+        <Tabs defaultValue="review" className="w-full">
+            <TabsList className="w-full">
+                <TabsTrigger value="review" className="flex-1 gap-1.5">
+                    <FileSearch className="h-3.5 w-3.5" />
+                    Review
+                </TabsTrigger>
+                <TabsTrigger value="edit" className="flex-1 gap-1.5">
+                    <FileEdit className="h-3.5 w-3.5" />
+                    Edit
+                </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="review" className="mt-3">
+                <ChapterReviewPanel />
+            </TabsContent>
+
+            <TabsContent value="edit" className="mt-3">
+                <ChapterEditContent />
+            </TabsContent>
+        </Tabs>
+    );
+}

--- a/src/features/chapters/components/ChapterReviewPanel.tsx
+++ b/src/features/chapters/components/ChapterReviewPanel.tsx
@@ -3,7 +3,7 @@
  * to produce editorial feedback. Uses the existing agentic generation infrastructure.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Bot, Copy, FileSearch, Loader2, RotateCcw, SquareX } from 'lucide-react';
+import { ArrowRight, Bot, Copy, FileSearch, Loader2, RotateCcw, SquareX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
@@ -16,7 +16,7 @@ import { useAgenticGeneration } from '@/features/agents/hooks/useAgenticGenerati
 import type { PipelinePreset } from '@/types/story';
 import { toast } from 'react-toastify';
 
-export function ChapterReviewPanel() {
+export function ChapterReviewPanel({ onSendToEdit }: { onSendToEdit?: (reviewText: string) => void } = {}) {
     const { currentChapterId, currentStoryId } = useStoryContext();
     const { currentChapter, getChapterPlainText } = useChapterStore();
     const { entries: lorebookEntries } = useLorebookStore();
@@ -185,7 +185,7 @@ export function ChapterReviewPanel() {
                     value={reviewFocus}
                     onChange={(e) => setReviewFocus(e.target.value)}
                     disabled={isGenerating}
-                    className="resize-none text-sm"
+                    className="resize-y text-sm"
                 />
             </div>
 
@@ -232,17 +232,19 @@ export function ChapterReviewPanel() {
                             <Bot className="h-4 w-4" />
                             Review
                         </div>
-                        {displayOutput && (
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-7 w-7"
-                                onClick={() => handleCopy(displayOutput)}
-                                title="Copy review"
-                            >
-                                <Copy className="h-3 w-3" />
-                            </Button>
-                        )}
+                        <div className="flex items-center gap-1">
+                            {displayOutput && (
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7"
+                                    onClick={() => handleCopy(displayOutput)}
+                                    title="Copy review"
+                                >
+                                    <Copy className="h-3 w-3" />
+                                </Button>
+                            )}
+                        </div>
                     </div>
                     <div
                         ref={outputRef}
@@ -290,6 +292,18 @@ export function ChapterReviewPanel() {
                 <p className="text-xs text-muted-foreground text-center">
                     {stepResults.length} agent step{stepResults.length !== 1 ? 's' : ''} completed
                 </p>
+            )}
+
+            {/* Send to Edit button — only shown when review is complete and parent supports it */}
+            {!isGenerating && finalOutput && onSendToEdit && (
+                <Button
+                    variant="default"
+                    className="w-full"
+                    onClick={() => onSendToEdit(finalOutput)}
+                >
+                    <ArrowRight className="h-4 w-4 mr-2" />
+                    Send Review to Edit Tab
+                </Button>
             )}
         </div>
     );

--- a/src/features/chapters/components/ChapterReviewPanel.tsx
+++ b/src/features/chapters/components/ChapterReviewPanel.tsx
@@ -1,0 +1,296 @@
+/**
+ * ChapterReviewPanel — runs an AI agent pipeline against the full text of the current chapter
+ * to produce editorial feedback. Uses the existing agentic generation infrastructure.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Bot, Copy, FileSearch, Loader2, RotateCcw, SquareX } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { useStoryContext } from '@/features/stories/context/StoryContext';
+import { useChapterStore } from '@/features/chapters/stores/useChapterStore';
+import { useLorebookStore } from '@/features/lorebook/stores/useLorebookStore';
+import { useAgenticGeneration } from '@/features/agents/hooks/useAgenticGeneration';
+import type { PipelinePreset } from '@/types/story';
+import { toast } from 'react-toastify';
+
+export function ChapterReviewPanel() {
+    const { currentChapterId, currentStoryId } = useStoryContext();
+    const { currentChapter, getChapterPlainText } = useChapterStore();
+    const { entries: lorebookEntries } = useLorebookStore();
+
+    const {
+        isGenerating,
+        currentAgentName,
+        stepResults,
+        generateWithPipeline,
+        abortGeneration,
+        getAvailablePipelines,
+    } = useAgenticGeneration();
+
+    const [pipelines, setPipelines] = useState<PipelinePreset[]>([]);
+    const [selectedPipelineId, setSelectedPipelineId] = useState<string>('');
+    const [reviewFocus, setReviewFocus] = useState('');
+    const [streamedOutput, setStreamedOutput] = useState('');
+    const [finalOutput, setFinalOutput] = useState('');
+    const [hasRun, setHasRun] = useState(false);
+    const [additionalResults, setAdditionalResults] = useState<{ agentName: string; output: string }[]>([]);
+    const outputRef = useRef<HTMLDivElement>(null);
+
+    // Load pipelines on mount
+    useEffect(() => {
+        getAvailablePipelines().then((all) => {
+            setPipelines(all);
+            // Default to "Chapter Review" pipeline if available, otherwise first pipeline
+            const reviewPipeline = all.find(
+                (p) => p.name.toLowerCase().includes('chapter review') || p.name.toLowerCase().includes('chapter deep review')
+            );
+            if (reviewPipeline) {
+                setSelectedPipelineId(reviewPipeline.id);
+            } else if (all.length > 0) {
+                setSelectedPipelineId(all[0].id);
+            }
+        });
+    }, [getAvailablePipelines]);
+
+    // Scroll output to bottom when streaming
+    useEffect(() => {
+        if (outputRef.current) {
+            outputRef.current.scrollTop = outputRef.current.scrollHeight;
+        }
+    }, [streamedOutput]);
+
+    const handleRun = useCallback(async () => {
+        if (!currentChapterId || !selectedPipelineId) {
+            toast.error('No chapter or pipeline selected');
+            return;
+        }
+
+        // Grab full plain text of the chapter
+        let chapterText = '';
+        try {
+            chapterText = await getChapterPlainText(currentChapterId);
+        } catch {
+            toast.error('Failed to extract chapter text');
+            return;
+        }
+
+        if (!chapterText.trim()) {
+            toast.error('The chapter appears to be empty — nothing to review');
+            return;
+        }
+
+        setStreamedOutput('');
+        setFinalOutput('');
+        setAdditionalResults([]);
+        setHasRun(true);
+
+        const result = await generateWithPipeline(
+            selectedPipelineId,
+            {
+                scenebeat: reviewFocus,
+                // Full chapter text is the primary input for the reviewer
+                previousWords: chapterText,
+                matchedEntries: lorebookEntries,
+                allEntries: lorebookEntries,
+                povType: currentChapter?.povType,
+                povCharacter: currentChapter?.povCharacter,
+                currentChapter: currentChapter ?? undefined,
+            },
+            {
+                onToken: (token) => {
+                    setStreamedOutput((prev) => prev + token);
+                },
+                onStepComplete: (stepResult) => {
+                    // Capture non-streaming step outputs (e.g. lore_judge, continuity_checker)
+                    if (stepResult.role !== 'chapter_reviewer') {
+                        setAdditionalResults((prev) => [
+                            ...prev,
+                            { agentName: stepResult.agentName, output: stepResult.output },
+                        ]);
+                    }
+                },
+                onComplete: (r) => {
+                    setFinalOutput(r.finalOutput);
+                    setStreamedOutput('');
+                },
+                onError: (err) => {
+                    toast.error(`Review failed: ${err.message}`);
+                },
+            }
+        );
+
+        if (!result) return;
+    }, [
+        currentChapterId,
+        selectedPipelineId,
+        reviewFocus,
+        getChapterPlainText,
+        lorebookEntries,
+        currentChapter,
+        generateWithPipeline,
+    ]);
+
+    const handleCopy = async (text: string) => {
+        try {
+            await navigator.clipboard.writeText(text);
+            toast.success('Copied to clipboard');
+        } catch {
+            toast.error('Failed to copy');
+        }
+    };
+
+    const handleReset = () => {
+        setStreamedOutput('');
+        setFinalOutput('');
+        setAdditionalResults([]);
+        setHasRun(false);
+    };
+
+    const displayOutput = finalOutput || streamedOutput;
+
+    return (
+        <div className="flex flex-col gap-4 pt-2">
+            {/* Pipeline selector */}
+            <div className="space-y-1">
+                <Label htmlFor="chapter-review-pipeline">Pipeline</Label>
+                <Select value={selectedPipelineId} onValueChange={setSelectedPipelineId} disabled={isGenerating}>
+                    <SelectTrigger id="chapter-review-pipeline">
+                        <SelectValue placeholder="Select a pipeline…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {pipelines.map((p) => (
+                            <SelectItem key={p.id} value={p.id}>
+                                {p.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                {pipelines.find((p) => p.id === selectedPipelineId)?.description && (
+                    <p className="text-xs text-muted-foreground">
+                        {pipelines.find((p) => p.id === selectedPipelineId)!.description}
+                    </p>
+                )}
+            </div>
+
+            {/* Optional focus instructions */}
+            <div className="space-y-1">
+                <Label htmlFor="chapter-review-focus">Review Focus (optional)</Label>
+                <Textarea
+                    id="chapter-review-focus"
+                    placeholder="e.g. Focus on dialogue consistency and pacing in the second half…"
+                    rows={3}
+                    value={reviewFocus}
+                    onChange={(e) => setReviewFocus(e.target.value)}
+                    disabled={isGenerating}
+                    className="resize-none text-sm"
+                />
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex items-center gap-2">
+                {!isGenerating ? (
+                    <Button
+                        onClick={handleRun}
+                        disabled={!selectedPipelineId || !currentChapterId}
+                        className="flex-1"
+                    >
+                        <FileSearch className="h-4 w-4 mr-2" />
+                        {hasRun ? 'Run Again' : 'Review Chapter'}
+                    </Button>
+                ) : (
+                    <Button variant="destructive" onClick={abortGeneration} className="flex-1">
+                        <SquareX className="h-4 w-4 mr-2" />
+                        Stop
+                    </Button>
+                )}
+
+                {hasRun && !isGenerating && (
+                    <Button variant="outline" size="icon" onClick={handleReset} title="Clear results">
+                        <RotateCcw className="h-4 w-4" />
+                    </Button>
+                )}
+            </div>
+
+            {/* Progress indicator */}
+            {isGenerating && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>
+                        {currentAgentName ? `Running: ${currentAgentName}` : 'Starting…'}
+                    </span>
+                </div>
+            )}
+
+            {/* Streaming / final review output */}
+            {(displayOutput || isGenerating) && (
+                <div className="space-y-1">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-1 text-sm font-medium">
+                            <Bot className="h-4 w-4" />
+                            Review
+                        </div>
+                        {displayOutput && (
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7"
+                                onClick={() => handleCopy(displayOutput)}
+                                title="Copy review"
+                            >
+                                <Copy className="h-3 w-3" />
+                            </Button>
+                        )}
+                    </div>
+                    <div
+                        ref={outputRef}
+                        className="rounded-md border bg-muted/30 p-3 text-sm whitespace-pre-wrap max-h-[50vh] overflow-y-auto leading-relaxed"
+                    >
+                        {displayOutput || (
+                            <span className="text-muted-foreground italic">Generating review…</span>
+                        )}
+                        {isGenerating && (
+                            <span className="inline-block w-1 h-4 bg-primary ml-0.5 animate-pulse" />
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {/* Additional agent outputs (lore judge, continuity checker, etc.) */}
+            {additionalResults.length > 0 && (
+                <div className="space-y-3">
+                    {additionalResults.map((r, idx) => (
+                        <div key={idx} className="space-y-1">
+                            <div className="flex items-center justify-between">
+                                <Badge variant="outline" className="text-xs">
+                                    {r.agentName}
+                                </Badge>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7"
+                                    onClick={() => handleCopy(r.output)}
+                                    title={`Copy ${r.agentName} output`}
+                                >
+                                    <Copy className="h-3 w-3" />
+                                </Button>
+                            </div>
+                            <div className="rounded-md border bg-muted/20 p-3 text-sm whitespace-pre-wrap max-h-[30vh] overflow-y-auto leading-relaxed">
+                                {r.output}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Completed step summary */}
+            {!isGenerating && stepResults.length > 0 && (
+                <p className="text-xs text-muted-foreground text-center">
+                    {stepResults.length} agent step{stepResults.length !== 1 ? 's' : ''} completed
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/features/chapters/components/StoryEditor.tsx
+++ b/src/features/chapters/components/StoryEditor.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BookOpen, Tags, Maximize, Minimize, User, Download, StickyNote, MoreVertical, ArrowLeft, FileText, Settings, HelpCircle, ScrollText, Book } from "lucide-react";
+import { BookOpen, Tags, Maximize, Minimize, User, Download, StickyNote, MoreVertical, ArrowLeft, FileText, Settings, HelpCircle, ScrollText, Book, Microscope } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import EmbeddedPlayground from "@/Lexical/lexical-playground/src/EmbeddedPlayground";
 import { MatchedTagEntries } from "@/features/chapters/components/MatchedTagEntries";
@@ -18,6 +18,7 @@ import { useStoryContext } from "@/features/stories/context/StoryContext";
 import { DownloadMenu } from "@/components/ui/DownloadMenu";
 import { ChapterNotesEditor } from "@/features/chapters/components/ChapterNotesEditor";
 import { DraftsPanel } from "@/features/drafts/components/DraftsPanel";
+import { AIEditorialPanel } from "@/features/chapters/components/AIEditorialPanel";
 import { AISettingsPanel } from "@/features/ai/components/AISettingsPanel";
 import { PromptsPanel } from "@/features/prompts/components/PromptsPanel";
 import { LorebookPanel } from "@/features/lorebook/components/LorebookPanel";
@@ -44,7 +45,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useNavigate } from "react-router";
 
-type DrawerType = "matchedTags" | "chapterOutline" | "chapterPOV" | "chapterNotes" | "drafts" | "aiSettings" | "guide" | "prompts" | "lorebook" | null;
+type DrawerType = "matchedTags" | "chapterOutline" | "chapterPOV" | "chapterNotes" | "drafts" | "aiSettings" | "guide" | "prompts" | "lorebook" | "chapterReview" | null;
 
 export function StoryEditor() {
     const [openDrawer, setOpenDrawer] = useState<DrawerType>(null);
@@ -158,6 +159,16 @@ export function StoryEditor() {
             </Button>
 
             <Button
+                variant={openDrawer === "chapterReview" ? "default" : "outline"}
+                size="sm"
+                className="mx-2 justify-start"
+                onClick={() => handleOpenDrawer("chapterReview")}
+            >
+                <Microscope className="h-4 w-4 mr-2" />
+                AI Editorial
+            </Button>
+
+            <Button
                 variant={openDrawer === "aiSettings" ? "default" : "outline"}
                 size="sm"
                 className="mx-2 justify-start"
@@ -238,6 +249,10 @@ export function StoryEditor() {
                         <DropdownMenuItem onClick={() => handleOpenDrawer("prompts")}>
                             <ScrollText className="h-4 w-4 mr-2" />
                             Prompts
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleOpenDrawer("chapterReview")}>
+                            <Microscope className="h-4 w-4 mr-2" />
+                            AI Editorial
                         </DropdownMenuItem>
                         <DropdownMenuItem onClick={() => handleOpenDrawer("aiSettings")}>
                             <Settings className="h-4 w-4 mr-2" />
@@ -417,6 +432,20 @@ export function StoryEditor() {
                     </div>
                 </SheetContent>
             </Sheet>
-        </div>
+
+            {/* AI Editorial Sheet */}
+            <Sheet open={openDrawer === "chapterReview"} onOpenChange={(open) => !open && setOpenDrawer(null)}>
+                <SheetContent
+                    side="right"
+                    className="h-[100vh] w-full md:min-w-[600px] md:w-auto"
+                >
+                    <SheetHeader>
+                        <SheetTitle>AI Editorial</SheetTitle>
+                    </SheetHeader>
+                    <div className="overflow-y-auto h-[calc(100vh-80px)] px-4 pt-2">
+                        <AIEditorialPanel />
+                    </div>
+                </SheetContent>
+            </Sheet>        </div>
     );
 }

--- a/src/features/chapters/components/StoryEditor.tsx
+++ b/src/features/chapters/components/StoryEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
-import { BookOpen, Tags, Maximize, Minimize, User, Download, StickyNote, MoreVertical, ArrowLeft, FileText, Settings, HelpCircle, ScrollText, Book, Microscope } from "lucide-react";
+import { BookOpen, Tags, Maximize, Minimize, User, Download, StickyNote, MoreVertical, ArrowLeft, FileText, Settings, HelpCircle, ScrollText, Book, Microscope, Loader2, Check } from "lucide-react";
+import { useChapterStore } from "@/features/chapters/stores/useChapterStore";
 import { Button } from "@/components/ui/button";
 import EmbeddedPlayground from "@/Lexical/lexical-playground/src/EmbeddedPlayground";
 import { MatchedTagEntries } from "@/features/chapters/components/MatchedTagEntries";
@@ -52,6 +53,7 @@ export function StoryEditor() {
     const [isMaximized, setIsMaximized] = useState(false);
     const [editorialWidth, setEditorialWidth] = useState(480);
     const { currentChapterId, currentStoryId } = useStoryContext();
+    const saveStatus = useChapterStore((s) => s.saveStatus);
     const isMobile = useIsMobile();
     const navigate = useNavigate();
 
@@ -93,6 +95,18 @@ export function StoryEditor() {
             {isMaximized ? <Minimize className="h-4 w-4" /> : <Maximize className="h-4 w-4" />}
         </Button>
     );
+
+    const saveIndicator = saveStatus === 'saving' ? (
+        <span className="flex items-center gap-1 text-xs text-muted-foreground px-2">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Saving…
+        </span>
+    ) : saveStatus === 'saved' ? (
+        <span className="flex items-center gap-1 text-xs text-green-600 px-2">
+            <Check className="h-3 w-3" />
+            Saved
+        </span>
+    ) : null;
 
     // Sidebar content for both desktop and mobile dropdown
     const sidebarButtons = (
@@ -222,6 +236,12 @@ export function StoryEditor() {
 
             {/* Desktop: Right Sidebar with Buttons */}
             <div className="hidden md:flex w-48 border-l h-full flex-col py-4 space-y-2 bg-muted/20 flex-shrink-0">
+                {/* Save status indicator */}
+                {saveIndicator && (
+                    <div className="mx-2 pb-1 border-b">
+                        {saveIndicator}
+                    </div>
+                )}
                 {sidebarButtons}
             </div>
 

--- a/src/features/chapters/components/StoryEditor.tsx
+++ b/src/features/chapters/components/StoryEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { BookOpen, Tags, Maximize, Minimize, User, Download, StickyNote, MoreVertical, ArrowLeft, FileText, Settings, HelpCircle, ScrollText, Book, Microscope } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import EmbeddedPlayground from "@/Lexical/lexical-playground/src/EmbeddedPlayground";
@@ -50,9 +50,30 @@ type DrawerType = "matchedTags" | "chapterOutline" | "chapterPOV" | "chapterNote
 export function StoryEditor() {
     const [openDrawer, setOpenDrawer] = useState<DrawerType>(null);
     const [isMaximized, setIsMaximized] = useState(false);
+    const [editorialWidth, setEditorialWidth] = useState(480);
     const { currentChapterId, currentStoryId } = useStoryContext();
     const isMobile = useIsMobile();
     const navigate = useNavigate();
+
+    const startEditorialDrag = useCallback((e: React.MouseEvent) => {
+        e.preventDefault();
+        const startX = e.clientX;
+        const startWidth = editorialWidth;
+        const onMouseMove = (ev: MouseEvent) => {
+            // dragging left increases width (panel is on the right)
+            const next = Math.min(
+                Math.max(startWidth + (startX - ev.clientX), 320),
+                window.innerWidth - 80
+            );
+            setEditorialWidth(next);
+        };
+        const onMouseUp = () => {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+        };
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+    }, [editorialWidth]);
 
     const handleOpenDrawer = (drawer: DrawerType) => {
         setOpenDrawer(drawer === openDrawer ? null : drawer);
@@ -434,16 +455,30 @@ export function StoryEditor() {
             </Sheet>
 
             {/* AI Editorial Sheet */}
-            <Sheet open={openDrawer === "chapterReview"} onOpenChange={(open) => !open && setOpenDrawer(null)}>
+            <Sheet open={openDrawer === "chapterReview"} onOpenChange={(open) => { if (!open) { setOpenDrawer(null); setEditorialWidth(480); } }}>
                 <SheetContent
                     side="right"
-                    className="h-[100vh] w-full md:min-w-[600px] md:w-auto"
+                    className="h-[100vh] w-full max-w-none overflow-hidden"
+                    style={{ width: `${editorialWidth}px` }}
                 >
+                    {/* Drag handle on the left edge */}
+                    <div
+                        className="absolute left-0 top-0 bottom-0 w-2 cursor-col-resize z-10 hover:bg-primary/20 active:bg-primary/30 transition-colors"
+                        onMouseDown={startEditorialDrag}
+                    />
                     <SheetHeader>
                         <SheetTitle>AI Editorial</SheetTitle>
                     </SheetHeader>
                     <div className="overflow-y-auto h-[calc(100vh-80px)] px-4 pt-2">
-                        <AIEditorialPanel />
+                        <AIEditorialPanel
+                            isExpanded={editorialWidth > 750}
+                            onExpandChange={(expand) =>
+                                setEditorialWidth(expand
+                                    ? Math.round(window.innerWidth * 0.9)
+                                    : 480
+                                )
+                            }
+                        />
                     </div>
                 </SheetContent>
             </Sheet>        </div>

--- a/src/features/chapters/stores/useChapterStore.ts
+++ b/src/features/chapters/stores/useChapterStore.ts
@@ -9,6 +9,8 @@ interface ChapterState {
     error: string | null;
     summariesSoFar: string;
     lastEditedChapterIds: Record<string, string>; // Map of storyId -> chapterId
+    /** 'idle' | 'saving' | 'saved' — driven by SaveChapterContentPlugin */
+    saveStatus: 'idle' | 'saving' | 'saved';
 
     // Actions
     fetchChapters: (storyId: string) => Promise<void>;
@@ -42,6 +44,7 @@ export const useChapterStore = create<ChapterState>((set, get) => ({
     loading: false,
     error: null,
     summariesSoFar: '',
+    saveStatus: 'idle',
     lastEditedChapterIds: JSON.parse(localStorage.getItem('lastEditedChapterIds') || '{}'),
 
     // Fetch all chapters for a story

--- a/src/features/prompts/components/PromptList.tsx
+++ b/src/features/prompts/components/PromptList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { usePromptStore } from '../store/promptStore';
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Trash2, Copy, Check, ChevronDown, ChevronRight } from 'lucide-react';
 import { toast } from 'react-toastify';
 import type { Prompt } from '@/types/story';
@@ -10,6 +11,8 @@ interface PromptsListProps {
     onPromptSelect: (prompt: Prompt) => void;
     selectedPromptId?: string;
     onPromptDelete: (promptId: string) => void;
+    selectedPromptIds?: string[];
+    onSelectionChange?: (ids: string[]) => void;
 }
 
 const getPromptTypeLabel = (type: Prompt['promptType']) => {
@@ -24,10 +27,26 @@ const getPromptTypeLabel = (type: Prompt['promptType']) => {
     return labels[type];
 };
 
-export function PromptsList({ onPromptSelect, selectedPromptId, onPromptDelete }: PromptsListProps) {
+export function PromptsList({ onPromptSelect, selectedPromptId, onPromptDelete, selectedPromptIds = [], onSelectionChange }: PromptsListProps) {
     const { prompts, fetchPrompts, deletePrompt, clonePrompt, isLoading, error } = usePromptStore();
     // Track which groups are expanded (default all expanded)
     const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+
+    const handleToggleSelect = (promptId: string) => {
+        const newSelection = selectedPromptIds.includes(promptId)
+            ? selectedPromptIds.filter(id => id !== promptId)
+            : [...selectedPromptIds, promptId];
+        onSelectionChange?.(newSelection);
+    };
+
+    const handleSelectAllInGroup = (groupPrompts: Prompt[]) => {
+        const promptIdsInGroup = groupPrompts.map(p => p.id);
+        const allSelected = promptIdsInGroup.every(id => selectedPromptIds.includes(id));
+        const newSelection = allSelected
+            ? selectedPromptIds.filter(id => !promptIdsInGroup.includes(id))
+            : [...new Set([...selectedPromptIds, ...promptIdsInGroup])];
+        onSelectionChange?.(newSelection);
+    };
 
     useEffect(() => {
         fetchPrompts().catch(error => {
@@ -127,6 +146,8 @@ export function PromptsList({ onPromptSelect, selectedPromptId, onPromptDelete }
                 if (promptsInGroup.length === 0) return null;
 
                 const isExpanded = expandedGroups[promptType] ?? true;
+                const allSelected = promptsInGroup.every(p => selectedPromptIds.includes(p.id));
+                const someSelected = promptsInGroup.some(p => selectedPromptIds.includes(p.id));
 
                 return (
                     <div key={promptType} className="mb-2">
@@ -134,10 +155,16 @@ export function PromptsList({ onPromptSelect, selectedPromptId, onPromptDelete }
                             onClick={() => toggleGroup(promptType)}
                             className="w-full px-4 py-2.5 bg-slate-300 dark:bg-slate-700 font-medium text-sm sticky top-0 shadow-sm border-b border-slate-500 dark:border-slate-600 flex items-center justify-between z-10 text-slate-800 dark:text-white hover:bg-slate-500 dark:hover:bg-slate-600 transition-colors cursor-pointer"
                         >
-                            <div className="flex items-center">
+                            <div className="flex items-center gap-2">
+                                <Checkbox
+                                    checked={allSelected}
+                                    onCheckedChange={() => handleSelectAllInGroup(promptsInGroup)}
+                                    onClick={(e) => e.stopPropagation()}
+                                    aria-label={`Select all ${promptType} prompts`}
+                                />
                                 {isExpanded ?
-                                    <ChevronDown className="h-4 w-4 mr-1.5" /> :
-                                    <ChevronRight className="h-4 w-4 mr-1.5" />
+                                    <ChevronDown className="h-4 w-4" /> :
+                                    <ChevronRight className="h-4 w-4" />
                                 }
                                 {getPromptTypeLabel(promptType)}
                                 <span className="ml-2 px-2 py-0.5 text-xs bg-slate-200 dark:bg-slate-500 text-slate-800 dark:text-white rounded-full font-semibold">
@@ -152,35 +179,47 @@ export function PromptsList({ onPromptSelect, selectedPromptId, onPromptDelete }
                                         key={prompt.id}
                                         className={cn(
                                             "group relative",
-                                            selectedPromptId === prompt.id && "bg-muted border-l-2 border-emerald-600 dark:border-emerald-400"
+                                            selectedPromptId === prompt.id && "bg-muted border-l-2 border-emerald-600 dark:border-emerald-400",
+                                            selectedPromptIds.includes(prompt.id) && "bg-primary/5"
                                         )}
                                     >
                                         <button
-                                            onClick={() => onPromptSelect(prompt)}
+                                            onClick={() => {
+                                                handleToggleSelect(prompt.id);
+                                                onPromptSelect(prompt);
+                                            }}
                                             className={cn(
-                                                "w-full text-left p-4 hover:bg-muted transition-colors",
+                                                "w-full text-left p-4 hover:bg-muted transition-colors flex items-center gap-3",
                                                 "focus:outline-none focus:bg-muted",
                                             )}
                                         >
-                                            <div className="flex items-center">
-                                                <h3 className={cn(
-                                                    "font-medium",
-                                                    selectedPromptId === prompt.id
-                                                        ? "text-emerald-600 dark:text-emerald-400 font-semibold"
-                                                        : "text-foreground"
-                                                )}>
-                                                    {prompt.name}
-                                                </h3>
-                                                {prompt.isSystem && (
-                                                    <span className="ml-2 px-1.5 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded">
-                                                        System
+                                            <Checkbox
+                                                checked={selectedPromptIds.includes(prompt.id)}
+                                                onCheckedChange={() => handleToggleSelect(prompt.id)}
+                                                onClick={(e) => e.stopPropagation()}
+                                                aria-label={`Select ${prompt.name}`}
+                                            />
+                                            <div className="flex-1">
+                                                <div className="flex items-center">
+                                                    <h3 className={cn(
+                                                        "font-medium",
+                                                        selectedPromptId === prompt.id
+                                                            ? "text-emerald-600 dark:text-emerald-400 font-semibold"
+                                                            : "text-foreground"
+                                                    )}>
+                                                        {prompt.name}
+                                                    </h3>
+                                                    {prompt.isSystem && (
+                                                        <span className="ml-2 px-1.5 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded">
+                                                            System
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <div className="flex items-center gap-2 mt-1">
+                                                    <span className="text-xs text-muted-foreground">
+                                                        {prompt.messages.length} messages
                                                     </span>
-                                                )}
-                                            </div>
-                                            <div className="flex items-center gap-2 mt-1">
-                                                <span className="text-xs text-muted-foreground">
-                                                    {prompt.messages.length} messages
-                                                </span>
+                                                </div>
                                             </div>
                                         </button>
 
@@ -216,4 +255,4 @@ export function PromptsList({ onPromptSelect, selectedPromptId, onPromptDelete }
             })}
         </div>
     );
-} 
+}

--- a/src/features/prompts/components/PromptsManager.tsx
+++ b/src/features/prompts/components/PromptsManager.tsx
@@ -4,7 +4,8 @@ import { PromptForm } from './PromptForm';
 import { PromptsList } from './PromptList';
 import { Plus, ArrowLeft, RefreshCw, Menu } from 'lucide-react';
 import { Upload, Download } from 'lucide-react';
-import type { Prompt } from '@/types/story';
+import { BulkUpdatePanel } from '@/components/BulkUpdatePanel';
+import type { Prompt, AllowedModel } from '@/types/story';
 import { cn } from '@/lib/utils';
 import { toast } from 'react-toastify';
 import { dbSeeder } from '@/services/dbSeed';
@@ -23,7 +24,10 @@ export function PromptsManager() {
     const [showMobileForm, setShowMobileForm] = useState(false);
     const [mobileListOpen, setMobileListOpen] = useState(false);
     const [isReseeding, setIsReseeding] = useState(false);
-    const { fetchPrompts } = usePromptStore();
+    const [selectedPromptIds, setSelectedPromptIds] = useState<string[]>([]);
+    const [showBulkUpdate, setShowBulkUpdate] = useState(false);
+    const [isApplyingBulkUpdate, setIsApplyingBulkUpdate] = useState(false);
+    const { fetchPrompts, bulkUpdatePrompts } = usePromptStore();
     const { exportPrompts, importPrompts } = usePromptStore();
     const [isImporting, setIsImporting] = useState(false);
     const fileInputRef = useState<HTMLInputElement | null>(null);
@@ -72,6 +76,21 @@ export function PromptsManager() {
             console.error('Error reseeding system prompts:', error);
         } finally {
             setIsReseeding(false);
+        }
+    };
+
+    const handleBulkUpdateModel = async (model: AllowedModel) => {
+        if (selectedPromptIds.length === 0) return;
+        
+        setIsApplyingBulkUpdate(true);
+        try {
+            await bulkUpdatePrompts(selectedPromptIds, {
+                allowedModels: [model]
+            });
+            setSelectedPromptIds([]);
+            setShowBulkUpdate(false);
+        } finally {
+            setIsApplyingBulkUpdate(false);
         }
     };
 
@@ -165,6 +184,13 @@ export function PromptsManager() {
                     onPromptSelect={handlePromptSelect}
                     selectedPromptId={selectedPrompt?.id}
                     onPromptDelete={handlePromptDelete}
+                    selectedPromptIds={selectedPromptIds}
+                    onSelectionChange={(ids) => {
+                        setSelectedPromptIds(ids);
+                        if (ids.length > 0) {
+                            setShowBulkUpdate(true);
+                        }
+                    }}
                 />
             </div>
         </>
@@ -233,32 +259,45 @@ export function PromptsManager() {
 
     // Desktop layout
     return (
-        <div className="flex h-full">
+        <div className="flex h-full flex-col">
             {/* Left panel - Fixed Sidebar */}
-            <div className="w-[300px] h-full border-r border-input bg-muted flex flex-col flex-shrink-0">
-                {sidebarContent}
-            </div>
+            <div className="flex-1 flex">
+                <div className="w-[300px] h-full border-r border-input bg-muted flex flex-col flex-shrink-0">
+                    {sidebarContent}
+                </div>
 
-            {/* Right panel - Content Area */}
-            <div className="flex-1 h-full overflow-auto">
-                <div className="max-w-3xl mx-auto p-6">
-                    {(isCreating || selectedPrompt) ? (
-                        <PromptForm
-                            key={selectedPrompt?.id || 'new'}
-                            prompt={selectedPrompt}
-                            onSave={handleSave}
-                            onCancel={() => {
-                                setIsCreating(false);
-                                setShowMobileForm(false);
-                            }}
-                        />
-                    ) : (
-                        <div className="flex items-center justify-center h-full text-muted-foreground">
-                            <p>Select a prompt to edit or create a new one</p>
-                        </div>
-                    )}
+                {/* Right panel - Content Area */}
+                <div className="flex-1 h-full overflow-auto">
+                    <div className="max-w-3xl mx-auto p-6">
+                        {(isCreating || selectedPrompt) ? (
+                            <PromptForm
+                                key={selectedPrompt?.id || 'new'}
+                                prompt={selectedPrompt}
+                                onSave={handleSave}
+                                onCancel={() => {
+                                    setIsCreating(false);
+                                    setShowMobileForm(false);
+                                }}
+                            />
+                        ) : (
+                            <div className="flex items-center justify-center h-full text-muted-foreground">
+                                <p>Select a prompt to edit or create a new one</p>
+                            </div>
+                        )}
+                    </div>
                 </div>
             </div>
+
+            <BulkUpdatePanel
+                selectedCount={selectedPromptIds.length}
+                isVisible={showBulkUpdate}
+                onClose={() => {
+                    setShowBulkUpdate(false);
+                    setSelectedPromptIds([]);
+                }}
+                onApplyModel={handleBulkUpdateModel}
+                isApplying={isApplyingBulkUpdate}
+            />
         </div>
     );
 } 

--- a/src/features/prompts/services/promptParser.ts
+++ b/src/features/prompts/services/promptParser.ts
@@ -341,14 +341,11 @@ export class PromptParser {
                                 // Add a separator to indicate content from previous chapter
                                 result = prevContent + '\n\n[...]\n\n' + result;
 
-                                console.log(`Added ${selectedPrevWords.length} words from previous chapter to context`);
                             }
                         }
                     } else {
-                        console.log('Previous chapter POV does not match current chapter POV, skipping');
                     }
                 } else {
-                    console.log('No previous chapter found');
                 }
             } catch (error) {
                 console.error('Error fetching previous chapter content:', error);
@@ -498,7 +495,6 @@ ${metadata?.relationships?.length ? '\nRelationships:\n' +
         const chapterStore = useChapterStore.getState();
 
         // Add debug log for the entire context
-        console.log('DEBUG: brainstormContext additionalContext:', context.additionalContext);
 
         // Load entries if they're not already loaded
         if (lorebookStore.entries.length === 0) {
@@ -580,45 +576,28 @@ ${metadata?.relationships?.length ? '\nRelationships:\n' +
 
         // Handle chapter content
         if (context.additionalContext?.selectedChapterContent?.length > 0) {
-            console.log('DEBUG: Processing selectedChapterContent:', context.additionalContext.selectedChapterContent);
-
             try {
                 const contents = await Promise.all(
                     context.additionalContext.selectedChapterContent.map(async id => {
-                        console.log(`DEBUG: Fetching content for chapter ID: ${id}`);
                         try {
                             const chapter = await db.chapters.get(id);
-                            console.log(`DEBUG: Chapter fetch result:`, chapter ? `Found chapter ${chapter.order}` : 'Not found');
-
                             if (!chapter) return '';
-
-                            console.log(`DEBUG: Getting plain text for chapter ${chapter.order}`);
                             const content = await chapterStore.getChapterPlainText(id);
-                            console.log(`DEBUG: Content length for chapter ${chapter.order}: ${content ? content.length : 0} chars`);
-
                             return `Chapter ${chapter.order} Content:\n${content}`;
                         } catch (err) {
-                            console.error(`DEBUG: Error processing chapter ${id}:`, err);
+                            console.error(`Error processing chapter ${id}:`, err);
                             return '';
                         }
                     })
                 );
 
-                console.log(`DEBUG: Contents array:`, contents);
                 const contentText = contents.filter(Boolean).join('\n\n');
-                console.log(`DEBUG: Final chapter content text:`, contentText.substring(0, 100) + '...');
-
                 if (contentText) {
                     result += `Full Chapter Content:\n${contentText}\n\n`;
-                    console.log('DEBUG: Added chapter content to result');
-                } else {
-                    console.log('DEBUG: No chapter content was added (empty content)');
                 }
             } catch (err) {
-                console.error('DEBUG: Error in chapter content processing:', err);
+                console.error('Error in chapter content processing:', err);
             }
-        } else {
-            console.log('DEBUG: No selectedChapterContent found or empty array');
         }
 
         // Handle lorebook entries

--- a/src/features/prompts/store/promptStore.ts
+++ b/src/features/prompts/store/promptStore.ts
@@ -14,6 +14,9 @@ interface PromptStore {
     deletePrompt: (id: string) => Promise<void>;
     clonePrompt: (id: string) => Promise<void>;
 
+    // Bulk Operations
+    bulkUpdatePrompts: (ids: string[], data: Partial<Prompt>) => Promise<void>;
+
     // Export/Import
     exportPrompts: () => Promise<void>;
     importPrompts: (jsonData: string) => Promise<void>;
@@ -152,6 +155,39 @@ export const usePromptStore = create<PromptStore>((set, get) => ({
             set({ prompts, error: null });
         } catch (error) {
             set({ error: (error as Error).message });
+            throw error;
+        }
+    },
+
+    // Bulk update multiple prompts with partial data
+    bulkUpdatePrompts: async (ids, data) => {
+        try {
+            if (data.messages && !get().validatePromptData(data.messages)) {
+                throw new Error('Invalid prompt data structure');
+            }
+
+            // If name is being updated, check for duplicates
+            if (data.name) {
+                for (const id of ids) {
+                    const existingPrompt = await db.prompts
+                        .where('name')
+                        .equals(data.name)
+                        .and(item => item.id !== id)
+                        .first();
+
+                    if (existingPrompt) {
+                        throw new Error(`A prompt with the name "${data.name}" already exists`);
+                    }
+                }
+            }
+
+            await db.prompts.bulkUpdate(
+                ids.map(id => ({ key: id, changes: data }))
+            );
+            const prompts = await db.prompts.toArray();
+            set({ prompts, error: null });
+        } catch (error) {
+            set({ error: null });
             throw error;
         }
     }

--- a/src/features/scenebeats/hooks/useSceneBeatGeneration.ts
+++ b/src/features/scenebeats/hooks/useSceneBeatGeneration.ts
@@ -269,7 +269,7 @@ export function useSceneBeatGeneration(store: SceneBeatInstanceStoreApi) {
                 onToken: (token) => store.getState().appendStreamedText(token),
                 onComplete: (pipelineResult) => {
                     console.log('[Agentic] Pipeline complete:', pipelineResult);
-                    store.setState({ streamComplete: true, showAgenticProgress: false });
+                    store.setState({ streaming: false, streamComplete: true, showAgenticProgress: false });
 
                     if (s.sceneBeatId) {
                         sceneBeatService.updateSceneBeat(s.sceneBeatId, {
@@ -280,6 +280,7 @@ export function useSceneBeatGeneration(store: SceneBeatInstanceStoreApi) {
                 },
                 onError: (error) => {
                     console.error('[Agentic] Error:', error);
+                    store.setState({ streaming: false, showAgenticProgress: false });
                     toast.error('Pipeline generation failed');
                 },
             };
@@ -292,6 +293,9 @@ export function useSceneBeatGeneration(store: SceneBeatInstanceStoreApi) {
         } catch (error) {
             console.error('[Agentic] Error:', error);
             toast.error('Failed to run agentic generation');
+        } finally {
+            // Guard: always clear streaming flag in case onComplete/onError wasn't called
+            store.setState((prev) => prev.streaming ? { streaming: false, showAgenticProgress: false } : {});
         }
     }, [store, editor, chapterMatchedEntries, agenticHook]);
 

--- a/src/features/scenebeats/stores/useSceneBeatInstanceStore.ts
+++ b/src/features/scenebeats/stores/useSceneBeatInstanceStore.ts
@@ -18,6 +18,39 @@ import type {
 } from '@/types/story';
 import { useLorebookStore } from '@/features/lorebook/stores/useLorebookStore';
 
+// ── Defaults persistence ────────────────────────────────────────
+// Last-used prompt/model/pipeline are saved globally so all SceneBeat
+// instances inherit the same defaults across sessions.
+
+const SCENEBEAT_DEFAULTS_KEY = 'scenebeat-defaults';
+
+interface SBDefaults {
+    promptId?: string;
+    modelId?: string;
+    modelName?: string;
+    modelProvider?: string;
+    pipelineId?: string;
+    agenticMode?: boolean;
+}
+
+function saveSBDefaults(data: Partial<SBDefaults>) {
+    try {
+        const existing = loadSBDefaults();
+        localStorage.setItem(SCENEBEAT_DEFAULTS_KEY, JSON.stringify({ ...existing, ...data }));
+    } catch {
+        // localStorage unavailable — silently ignore
+    }
+}
+
+export function loadSBDefaults(): SBDefaults {
+    try {
+        const raw = localStorage.getItem(SCENEBEAT_DEFAULTS_KEY);
+        return raw ? JSON.parse(raw) : {};
+    } catch {
+        return {};
+    }
+}
+
 // ── Types ──────────────────────────────────────────────────────
 export type PovType = 'First Person' | 'Third Person Limited' | 'Third Person Omniscient';
 
@@ -94,6 +127,8 @@ export interface SceneBeatInstanceState {
 
     // Prompt
     handlePromptSelect: (prompt: Prompt, model: AllowedModel) => void;
+    /** Restore last-used prompt/model/pipeline/agenticMode from localStorage */
+    hydrateFromDefaults: (prompts: Prompt[], pipelines: PipelinePreset[]) => void;
 
     // Context
     handleItemSelect: (itemId: string) => void;
@@ -172,7 +207,20 @@ export function createSceneBeatInstanceStore(nodeKey: string) {
 
         // ── Actions ────────────────────────────────────────────
 
-        set: (partial) => set(partial),
+        set: (partial) => {
+            set(partial);
+            // Persist agenticMode and selectedPipeline whenever they change
+            if ('agenticMode' in partial || 'selectedPipeline' in partial) {
+                const state = get();
+                const agenticMode = 'agenticMode' in partial
+                    ? (partial.agenticMode as boolean)
+                    : state.agenticMode;
+                const pipeline = 'selectedPipeline' in partial
+                    ? (partial.selectedPipeline as PipelinePreset | null)
+                    : state.selectedPipeline;
+                saveSBDefaults({ agenticMode, pipelineId: pipeline?.id });
+            }
+        },
 
         handlePovTypeChange: (value) => {
             set({ tempPovType: value });
@@ -196,6 +244,42 @@ export function createSceneBeatInstanceStore(nodeKey: string) {
                 previewMessages: undefined,
                 previewError: null,
             });
+            // Persist selection so next session starts with the same defaults
+            saveSBDefaults({
+                promptId: prompt.id,
+                modelId: model.id,
+                modelName: model.name,
+                modelProvider: model.provider,
+            });
+        },
+
+        hydrateFromDefaults: (prompts, pipelines) => {
+            // Only hydrate if nothing is already selected (don't overwrite manual choices)
+            const state = get();
+            const defaults = loadSBDefaults();
+
+            if (!state.selectedPrompt && defaults.promptId) {
+                const prompt = prompts.find(p => p.id === defaults.promptId);
+                if (prompt && defaults.modelId && defaults.modelProvider && defaults.modelName) {
+                    const model: AllowedModel = {
+                        id: defaults.modelId,
+                        name: defaults.modelName,
+                        provider: defaults.modelProvider as AllowedModel['provider'],
+                    };
+                    set({ selectedPrompt: prompt, selectedModel: model });
+                }
+            }
+
+            if (defaults.agenticMode !== undefined && !state.agenticMode) {
+                set({ agenticMode: defaults.agenticMode });
+            }
+
+            if (!state.selectedPipeline && defaults.pipelineId && pipelines.length > 0) {
+                const pipeline = pipelines.find(p => p.id === defaults.pipelineId);
+                if (pipeline) {
+                    set({ selectedPipeline: pipeline });
+                }
+            }
         },
 
         handleItemSelect: (itemId) => {

--- a/src/services/ai/AIService.ts
+++ b/src/services/ai/AIService.ts
@@ -356,13 +356,19 @@ export class AIService {
         top_p?: number,
         top_k?: number,
         repetition_penalty?: number,
-        min_p?: number
+        min_p?: number,
+        modelId?: string
     ): Promise<Response> {
+        // Strip the "local/" prefix — LMStudio expects bare model IDs (e.g. "llama-3.2-3b-instruct")
+        const bareModelId = modelId
+            ? modelId.replace(/^local\//, '')
+            : (this.settings?.availableModels?.find(m => m.provider === 'local')?.id ?? 'local').replace(/^local\//, '');
+
         // Create request body with optional parameters
         const requestBody: any = {
             messages,
             stream: true,
-            model: 'local/llama-3.2-3b-instruct',
+            model: bareModelId,
             temperature,
             max_tokens: maxTokens,
         };

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -298,8 +298,9 @@ export class AgentOrchestrator {
         // Push prompt mode: build multi-turn chat memory
         // [system, originalUser, assistantRefusal, pushPromptUser]
         if (isRevision && step?.pushPrompt && previousResults.length > 0) {
-            // Find the prose writer's original output (the refusal)
-            const proseResult = previousResults.find(r => r.role === 'prose_writer');
+            // Find the MOST RECENT prose writer output (last iteration, not first)
+            const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander'];
+            const proseResult = [...previousResults].reverse().find(r => proseRoles.includes(r.role));
             const previousOutput = proseResult?.output || previousResults[previousResults.length - 1]?.output || '';
 
             // Feedback from the checker (e.g. refusal_checker or lore_judge)
@@ -1059,7 +1060,7 @@ Provide the improved version:`;
 
         switch (model.provider) {
             case 'local':
-                return aiService.generateWithLocalModel(messages, temperature, maxTokens);
+                return aiService.generateWithLocalModel(messages, temperature, maxTokens, undefined, undefined, undefined, undefined, model.id);
             case 'openai':
                 return aiService.generateWithOpenAI(messages, model.id, temperature, maxTokens);
             case 'openrouter':

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -464,6 +464,12 @@ export class AgentOrchestrator {
             case 'scenebeat_generator':
                 return this.buildScenebeatGeneratorMessage(agent, input, previousResults);
 
+            case 'chapter_reviewer':
+                return this.buildChapterReviewerMessage(agent, input);
+
+            case 'chapter_editor':
+                return this.buildChapterEditorMessage(agent, input);
+
             case 'custom':
             default:
                 return this.buildCustomMessage(agent, input, previousResults);
@@ -646,8 +652,78 @@ Provide the improved version:`;
         return message;
     }
 
-    private buildCustomMessage(agent: AgentPreset, input: PipelineInput, previousResults: AgentResult[]): string {
-        const config = this.getEffectiveContextConfig(agent);
+    private buildChapterEditorMessage(agent: AgentPreset, input: PipelineInput): string {
+        const lorebookEntries = this.getLorebookForAgent(agent, input);
+        const chapterText = input.previousWords || '';
+        const editInstructions = input.scenebeat || '';
+
+        let message = '';
+
+        // Include lorebook so the editor can preserve lore-accurate details
+        if (lorebookEntries.length > 0) {
+            const lorebookContext = lorebookEntries
+                .map(e => `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${e.description}`)
+                .join('\n\n');
+            message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
+        }
+
+        // Add POV info so voice is preserved
+        if (input.povType) {
+            message += `POV: ${input.povType}`;
+            if (input.povCharacter) {
+                message += ` (${input.povCharacter})`;
+            }
+            message += '\n\n';
+        }
+
+        message += `CHAPTER TO EDIT:\n${chapterText}\n\n`;
+
+        if (editInstructions) {
+            message += `EDITING INSTRUCTIONS:\n${editInstructions}\n\n`;
+        }
+
+        message += `---\nReturn the complete edited chapter text and nothing else:`;
+
+        return message;
+    }
+
+    private buildChapterReviewerMessage(agent: AgentPreset, input: PipelineInput): string {        const lorebookEntries = this.getLorebookForAgent(agent, input);
+        const chapterText = input.previousWords || '';
+        const reviewFocus = input.scenebeat || '';
+
+        let message = '';
+
+        // Add lorebook context so the reviewer can check for lore consistency
+        if (lorebookEntries.length > 0) {
+            const lorebookContext = lorebookEntries
+                .map(e => `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${e.description}`)
+                .join('\n\n');
+            message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
+        }
+
+        // Add POV info if available
+        if (input.povType) {
+            message += `POV: ${input.povType}`;
+            if (input.povCharacter) {
+                message += ` (${input.povCharacter})`;
+            }
+            message += '\n\n';
+        }
+
+        // Add the chapter text to review
+        message += `CHAPTER TEXT TO REVIEW:\n${chapterText}\n\n`;
+
+        // Add optional reviewer focus/instructions
+        if (reviewFocus) {
+            message += `REVIEW FOCUS:\n${reviewFocus}\n\n`;
+        }
+
+        message += `---\nPlease provide a detailed review of the chapter above.`;
+
+        return message;
+    }
+
+    private buildCustomMessage(agent: AgentPreset, input: PipelineInput, previousResults: AgentResult[]): string {        const config = this.getEffectiveContextConfig(agent);
         const lorebookEntries = this.getLorebookForAgent(agent, input);
         const contextText = this.getPreviousWordsForAgent(agent, input, previousResults);
         

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -657,12 +657,21 @@ Provide the improved version:`;
         const chapterText = input.previousWords || '';
         const editInstructions = input.scenebeat || '';
 
+        // Cap each lorebook description to avoid token overflow when editing long chapters.
+        // The model must output the full chapter back, so we budget tightly for lore context.
+        const MAX_LORE_DESC_CHARS = 300;
+
         let message = '';
 
         // Include lorebook so the editor can preserve lore-accurate details
         if (lorebookEntries.length > 0) {
             const lorebookContext = lorebookEntries
-                .map(e => `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${e.description}`)
+                .map(e => {
+                    const desc = e.description.length > MAX_LORE_DESC_CHARS
+                        ? e.description.slice(0, MAX_LORE_DESC_CHARS) + '…'
+                        : e.description;
+                    return `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${desc}`;
+                })
                 .join('\n\n');
             message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
         }
@@ -691,12 +700,19 @@ Provide the improved version:`;
         const chapterText = input.previousWords || '';
         const reviewFocus = input.scenebeat || '';
 
+        const MAX_LORE_DESC_CHARS = 300;
+
         let message = '';
 
         // Add lorebook context so the reviewer can check for lore consistency
         if (lorebookEntries.length > 0) {
             const lorebookContext = lorebookEntries
-                .map(e => `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${e.description}`)
+                .map(e => {
+                    const desc = e.description.length > MAX_LORE_DESC_CHARS
+                        ? e.description.slice(0, MAX_LORE_DESC_CHARS) + '…'
+                        : e.description;
+                    return `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${desc}`;
+                })
                 .join('\n\n');
             message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
         }

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -274,6 +274,8 @@ export type AgentRole =
   | "style_extractor" // Extracts writing style from sample text
   | "scenebeat_generator" // Generates scene beat commands
   | "refusal_checker" // Detects if the LLM refused to generate content
+  | "chapter_reviewer" // Reviews an entire chapter for quality, consistency, and suggestions
+  | "chapter_editor" // Rewrites/edits an entire chapter based on instructions
   | "custom"; // User-defined agent role
 
 // Context configuration for agents - controls what data is sent to the LLM
@@ -375,6 +377,18 @@ export const DEFAULT_CONTEXT_CONFIG: Record<AgentRole, AgentContextConfig> = {
     previousWordsMode: "none",
     includeChapterSummary: false,
     includePovInfo: false,
+  },
+  chapter_reviewer: {
+    lorebookMode: "all",
+    previousWordsMode: "full",
+    includeChapterSummary: false,
+    includePovInfo: true,
+  },
+  chapter_editor: {
+    lorebookMode: "all",
+    previousWordsMode: "full",
+    includeChapterSummary: false,
+    includePovInfo: true,
   },
 };
 

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -203,6 +203,7 @@ export interface LorebookEntry extends BaseEntity {
     customFields?: Record<string, unknown>;
   };
   isDisabled?: boolean;
+  isValid?: boolean;
 }
 
 // Prompt Parser types


### PR DESCRIPTION
## Summary

This PR brings the fork up to date with upstream and resolves 5 critical bugs identified during a full code review.

### Upstream sync (commits e4b1da7, a4150c5)
- Cherry-picked `chapter_reviewer` and `chapter_editor` agent roles from `vijayk1989/TheStoryNexusTauriApp` (`feat-editorialReview` branch)
- Added `AIEditorialPanel`, `ChapterReviewPanel`, and `BulkUpdatePanel` UI components
- Added 4 new pipeline presets: Chapter Review, Chapter Deep Review, Chapter Edit, Chapter Review then Edit
- Added bulk update operations for agent presets, pipeline presets, and prompts (`bulkUpdateAgentPresets`, `resetSystemDefaults`)

### Bug fixes (commit ddf2113)

**1. Hardcoded local model ID — breaks all agentic local model generation** (`AIService.ts`, `AgentOrchestrator.ts`, `useAIStore.ts`)
- `generateWithLocalModel()` always sent `model: 'local/llama-3.2-3b-instruct'` regardless of what was configured
- Fixed: added `modelId?` parameter; strips `local/` prefix before sending to LMStudio
- `AgentOrchestrator.callModel()` and `useAIStore` now pass the actual selected model ID

**2. Revision loop uses stale output** (`AgentOrchestrator.ts`)
- `.find()` on `previousResults` returned the first prose writer result, not the most recent — multi-iteration loops always showed the AI its original unrevised output
- Fixed: use `[...previousResults].reverse().find()` and expand to all prose-producing roles

**3. Scene beat settings not persisted** (`useSceneBeatInstanceStore.ts`, `SceneBeatNode.tsx`)
- Selected prompt, model, pipeline, and agenticMode were Zustand in-memory only — lost on every reload
- Fixed: added `localStorage` persistence via `saveSBDefaults`/`loadSBDefaults` and a `hydrateFromDefaults` action called after prompts/pipelines load

**4. Auto-save data loss on fast navigation** (`SaveChapterContent/index.tsx`, `useChapterStore.ts`, `StoryEditor.tsx`)
- Debounce cleanup called `.cancel()` — up to 1 second of edits silently dropped when navigating away
- Fixed: changed to `.flush()` to force the pending write
- Added `saveStatus` field and a visible save indicator (spinner / `Saved ✓`) in the StoryEditor sidebar

**5. Streaming state stuck after agentic error** (`useSceneBeatGeneration.ts`)
- If agentic pipeline threw an error, `streaming: true` was never reset — UI locked until page reload
- Fixed: `onError` callback and catch block now set `streaming: false`; added `finally` safety net

### Other improvements
- `useAIStore.initialize()`: added `_initPromise` singleton guard to prevent duplicate concurrent init calls
- `promptParser.ts`: removed debug `console.log` statements

## Test plan
- [ ] Open a chapter, type text, navigate away within 1 second — content should be saved (check IndexedDB)
- [ ] Reload the app — scene beat prompt/model/pipeline/agenticMode should be restored automatically
- [ ] Run an agentic pipeline with a local LMStudio model — verify the configured model (not the hardcoded one) is used
- [ ] Run a pipeline with a revision loop — verify the push prompt references the most recently revised prose
- [ ] Trigger an agentic generation error — verify the generate button is re-enabled immediately (not stuck)
- [ ] Verify the AI Editorial panel and Chapter Review pipeline presets appear in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)