### PR TITLE
feat: add judge_aggregator role and fix revision loop execution

### DIFF
--- a/src/features/agents/components/AgentPresetForm.tsx
+++ b/src/features/agents/components/AgentPresetForm.tsx
@@ -54,6 +54,7 @@ const AGENT_ROLES: { value: AgentRole; label: string; description: string }[] = 
     { value: 'prose_writer', label: 'Prose Writer', description: 'Main creative writing agent' },
     { value: 'lore_judge', label: 'Lore Judge', description: 'Validates lore consistency' },
     { value: 'continuity_checker', label: 'Continuity Checker', description: 'Checks plot/character continuity' },
+    { value: 'judge_aggregator', label: 'Judge Aggregator', description: 'Synthesises all judge outputs since last prose into a single PASS or ISSUES_FOUND verdict' },
     { value: 'style_editor', label: 'Style Editor', description: 'Refines prose style and tone' },
     { value: 'dialogue_specialist', label: 'Dialogue Specialist', description: 'Improves dialogue authenticity' },
     { value: 'expander', label: 'Expander', description: 'Expands brief notes into prose' },

--- a/src/features/agents/components/AgentPresetList.tsx
+++ b/src/features/agents/components/AgentPresetList.tsx
@@ -40,6 +40,11 @@ const ROLE_COLORS: Record<AgentRole, string> = {
     style_extractor: 'bg-rose-500/10 text-rose-500 border-rose-500/20',
     scenebeat_generator: 'bg-teal-500/10 text-teal-500 border-teal-500/20',
     refusal_checker: 'bg-red-500/10 text-red-500 border-red-500/20',
+    chapter_reviewer: 'bg-violet-500/10 text-violet-500 border-violet-500/20',
+    chapter_editor: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/20',
+    lore_writer: 'bg-lime-500/10 text-lime-500 border-lime-500/20',
+    lore_refiner: 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20',
+    judge_aggregator: 'bg-orange-500/10 text-orange-500 border-orange-500/20',
     custom: 'bg-gray-500/10 text-gray-500 border-gray-500/20',
 };
 
@@ -55,6 +60,11 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     style_extractor: 'Style Extractor',
     scenebeat_generator: 'Scene Beat Generator',
     refusal_checker: 'Refusal Checker',
+    chapter_reviewer: 'Chapter Reviewer',
+    chapter_editor: 'Chapter Editor',
+    lore_writer: 'Lore Writer',
+    lore_refiner: 'Lore Refiner',
+    judge_aggregator: 'Judge Aggregator',
     custom: 'Custom',
 };
 

--- a/src/features/agents/components/PipelineDiagnosticsDialog.tsx
+++ b/src/features/agents/components/PipelineDiagnosticsDialog.tsx
@@ -31,13 +31,22 @@ function formatMessages(messages: PromptMessage[]): string {
     }).join('\n\n' + '─'.repeat(50) + '\n\n');
 }
 
+function judgeHasIssues(output: string): boolean {
+    const upper = output.toUpperCase().trim();
+    if (upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##')) return true;
+    if (upper.startsWith('ISSUES_FOUND')) return true;
+    if (upper.startsWith('CONSISTENT') || upper.startsWith('PASS')) return false;
+    return upper.includes('ISSUE') && !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
+}
+
 function getStatusIcon(result: AgentResult) {
     if (result.metadata?.error) {
         return <XCircle className="h-4 w-4 text-destructive" />;
     }
-    if (result.output.toUpperCase().includes('ISSUE') || 
-        result.output.toUpperCase().includes('INCONSISTENT') ||
-        result.output.toUpperCase().includes('ERROR')) {
+    const isJudgeRole = result.role === 'lore_judge' || result.role === 'continuity_checker' ||
+        result.role === 'judge_aggregator' ||
+        result.role.includes('judge') || result.role.includes('checker');
+    if (isJudgeRole && judgeHasIssues(result.output)) {
         return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
     }
     return <CheckCircle2 className="h-4 w-4 text-green-500" />;

--- a/src/features/agents/components/PipelinePresetForm.tsx
+++ b/src/features/agents/components/PipelinePresetForm.tsx
@@ -36,6 +36,11 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     style_extractor: 'Style Extractor',
     scenebeat_generator: 'Scene Beat Generator',
     refusal_checker: 'Refusal Checker',
+    chapter_reviewer: 'Chapter Reviewer',
+    chapter_editor: 'Chapter Editor',
+    lore_writer: 'Lore Writer',
+    lore_refiner: 'Lore Refiner',
+    judge_aggregator: 'Judge Aggregator',
     custom: 'Custom',
 };
 
@@ -51,6 +56,7 @@ const CONDITION_PRESETS = [
     { value: 'previousOutputNotContains:CONSISTENT', label: 'Previous output not "CONSISTENT"', actualValue: 'previousOutputNotContains:CONSISTENT' },
     { value: 'roleOutputContains:lore_judge:ISSUE', label: 'Lore Judge found issues', actualValue: 'roleOutputContains:lore_judge:ISSUE' },
     { value: 'roleOutputContains:continuity_checker:ISSUE', label: 'Continuity Checker found issues', actualValue: 'roleOutputContains:continuity_checker:ISSUE' },
+    { value: 'roleOutputContains:judge_aggregator:ISSUES_FOUND', label: 'Judge Aggregator found issues', actualValue: 'roleOutputContains:judge_aggregator:ISSUES_FOUND' },
     { value: 'hasLorebookEntries', label: 'Has lorebook entries', actualValue: 'hasLorebookEntries' },
     { value: 'hasPreviousOutput', label: 'Has previous step output', actualValue: 'hasPreviousOutput' },
     { value: 'custom', label: 'Custom condition...', actualValue: '' },

--- a/src/features/agents/components/PipelinePresetList.tsx
+++ b/src/features/agents/components/PipelinePresetList.tsx
@@ -40,6 +40,11 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     style_extractor: 'Style Extractor',
     scenebeat_generator: 'Scene Beat Generator',
     refusal_checker: 'Refusal Checker',
+    chapter_reviewer: 'Chapter Reviewer',
+    chapter_editor: 'Chapter Editor',
+    lore_writer: 'Lore Writer',
+    lore_refiner: 'Lore Refiner',
+    judge_aggregator: 'Judge Aggregator',
     custom: 'Custom',
 };
 

--- a/src/features/agents/services/agentSeeder.ts
+++ b/src/features/agents/services/agentSeeder.ts
@@ -83,6 +83,36 @@ const CONTEXT_CONFIGS: Record<string, AgentContextConfig> = {
         includeChapterSummary: false,
         includePovInfo: false,
     },
+    chapter_reviewer: {
+        lorebookMode: 'matched',
+        previousWordsMode: 'full',
+        includeChapterSummary: false,
+        includePovInfo: true,
+    },
+    chapter_editor: {
+        lorebookMode: 'matched',
+        previousWordsMode: 'full',
+        includeChapterSummary: false,
+        includePovInfo: true,
+    },
+    lore_writer: {
+        lorebookMode: 'none',
+        previousWordsMode: 'none',
+        includeChapterSummary: false,
+        includePovInfo: false,
+    },
+    lore_refiner: {
+        lorebookMode: 'none',
+        previousWordsMode: 'none',
+        includeChapterSummary: false,
+        includePovInfo: false,
+    },
+    judge_aggregator: {
+        lorebookMode: 'none',
+        previousWordsMode: 'none',
+        includeChapterSummary: false,
+        includePovInfo: false,
+    },
 };
 
 // System agent presets with template variables
@@ -158,10 +188,10 @@ Be thorough but concise. Focus on actual contradictions, not stylistic preferenc
     },
     {
         name: 'System Continuity Checker',
-        description: 'Checks for plot holes and character consistency.',
+        description: 'Checks for plot holes, character consistency, and in-scene physical detail drift.',
         role: 'continuity_checker',
         model: DEFAULT_MODELS.utility,
-        systemPrompt: `You are a continuity expert for fiction writing. Check for plot holes, timeline issues, and character consistency.
+        systemPrompt: `You are a continuity expert for fiction writing. Check for plot holes, timeline issues, character consistency, and in-scene physical detail drift.
 
 Review for:
 - Timeline inconsistencies (events happening out of order)
@@ -169,20 +199,49 @@ Review for:
 - Forgotten plot threads or unresolved setups
 - Physical impossibilities (character in two places at once)
 - Emotional continuity (reactions matching previous scenes)
+- In-scene appearance drift: clothing, jewellery, accessories, tattoos, hairstyle, injuries, or skin marks that change within the scene without explanation
+- Object state continuity: items placed, held, drawn, or described in one paragraph that are forgotten or contradicted later in the same scene
+- Physical state persistence: wounds, blood, mud, wet clothing, or dishevelled appearance that should persist across paragraphs unless explicitly addressed
+- Environmental state: doors open/closed, candles lit/unlit, weather or lighting established mid-scene that silently changes
 
-Response format:
-- If consistent, respond with exactly: CONSISTENT
-- If there are issues:
-  CONTINUITY ISSUE: [Description]
-  CONTEXT: [What was established earlier]
-  SUGGESTION: [How to resolve]
+Response format — FOLLOW EXACTLY:
+- If consistent: respond with only: CONSISTENT
+- If there are issues, use this exact format for each:
+  ##CONTINUITY_ISSUE##
+  DESCRIPTION: [what contradicts earlier content or changes without explanation]
+  CONTEXT: [what was previously established]
+  SUGGESTION: [how to resolve]
 
-Focus on narrative logic, not style preferences.`,
+Do NOT use the word "issue" outside of ##CONTINUITY_ISSUE## blocks.
+Focus on narrative logic and physical consistency, not style preferences.`,
         temperature: 0.2,
-        maxTokens: 600,
+        maxTokens: 800,
         isSystem: true,
         storyId: null,
         contextConfig: CONTEXT_CONFIGS.continuity_checker,
+    },
+    {
+        name: 'System Judge Aggregator',
+        description: 'Synthesises outputs from all judges since the last prose step into a single PASS or ISSUES_FOUND decision.',
+        role: 'judge_aggregator',
+        model: DEFAULT_MODELS.utility,
+        systemPrompt: `You are a judge aggregator for fiction writing. Your job is to review the outputs from multiple judge agents (lore judge, continuity checker, etc.) and produce a single clear verdict.
+
+Rules:
+- If ALL judges found no issues (each returned CONSISTENT or similar): respond with only: PASS
+- If ANY judge found issues: respond with ISSUES_FOUND on the first line, then a concise, prioritised list of the problems to fix and how to fix them.
+
+Format when issues exist:
+ISSUES_FOUND
+[Numbered list of issues, most critical first. For each: what is wrong and the suggested fix.]
+
+Be concise and actionable. Merge duplicate issues from different judges. Omit style preferences — only flag factual contradictions and continuity errors.
+Do NOT use the word "issue" outside of the ISSUES_FOUND block.`,
+        temperature: 0.2,
+        maxTokens: 800,
+        isSystem: true,
+        storyId: null,
+        contextConfig: CONTEXT_CONFIGS.judge_aggregator,
     },
     {
         name: 'System Style Editor',
@@ -351,6 +410,49 @@ const SYSTEM_PIPELINE_PRESETS: {
             { role: 'lore_judge' },
             // Revision step: only runs if lore judge found issues
             { role: 'prose_writer', condition: 'roleOutputContains:lore_judge:ISSUE', isRevision: true, streamOutput: true },
+        ],
+    },
+    {
+        name: 'Quality Prose with Verification',
+        description: 'Writes prose, checks lore, revises up to twice if issues found, then re-checks to confirm all issues were resolved.',
+        agentRoles: [
+            { role: 'summarizer', condition: 'wordCount > 3000' },  // 0
+            { role: 'prose_writer', streamOutput: true },            // 1
+            { role: 'lore_judge' },                                  // 2
+            // Revision step: executes up to 2 times when lore issues found,
+            // then jumps back to the lore_judge (step 2) to re-check the revised prose.
+            {
+                role: 'prose_writer',
+                condition: 'roleOutputContains:lore_judge:ISSUE',
+                isRevision: true,
+                streamOutput: true,
+                retryFromStep: 2,
+                maxIterations: 2,
+            },                                                       // 3
+            // Verification pass: re-runs the lore judge on the final revision to confirm resolution
+            { role: 'lore_judge' },                                  // 4
+        ],
+    },
+    {
+        name: 'Quality Prose with Judge Loop',
+        description: 'Writes prose, runs lore + continuity judges, aggregates feedback, then revises in a loop until all issues are resolved or the iteration limit is reached.',
+        agentRoles: [
+            { role: 'summarizer', condition: 'wordCount > 3000' },  // 0
+            { role: 'prose_writer', streamOutput: true },            // 1
+            { role: 'lore_judge' },                                  // 2
+            { role: 'continuity_checker' },                          // 3
+            { role: 'judge_aggregator' },                            // 4
+            // Revision step: executes up to 3 times when the aggregator finds issues,
+            // then jumps back to the lore_judge (step 2) so all judges re-check the
+            // revised prose before the next revision pass.
+            {
+                role: 'prose_writer',
+                condition: 'roleOutputContains:judge_aggregator:ISSUES_FOUND',
+                isRevision: true,
+                streamOutput: true,
+                retryFromStep: 2,
+                maxIterations: 3,
+            },                                                       // 5
         ],
     },
     {

--- a/src/features/agents/stores/useAgentsStore.ts
+++ b/src/features/agents/stores/useAgentsStore.ts
@@ -97,7 +97,77 @@ Output a concise style guide that another AI could use to mimic this writing sty
     Response format:
     - If the text contains a refusal or avoidance: respond with exactly: REFUSAL_DETECTED: [brief description of what was refused]
     - If the text is genuine creative prose (even if imperfect): respond with exactly: CONTENT_OK`,
-    custom: `You are a helpful AI assistant. Follow the instructions provided and assist with the writing task.`
+
+    chapter_reviewer: `You are an expert fiction editor and literary critic. Your job is to review a full chapter and provide detailed, constructive feedback.
+
+Review the chapter across the following dimensions:
+
+1. **Prose Quality**: Sentence variety, word choice, show vs. tell balance, rhythm and flow
+2. **Character Consistency**: Are characters acting true to their established traits? Is dialogue authentic?
+3. **Pacing**: Does the chapter move at an appropriate speed? Are there slow or rushed sections?
+4. **Scene Structure**: Is there a clear opening, middle, and payoff? Does tension build effectively?
+5. **Lore & Continuity**: Any contradictions with established world-building or character facts?
+6. **Dialogue**: Natural? Distinct character voices? Subtext present where appropriate?
+7. **Emotional Impact**: Does the chapter land emotionally? Does the reader feel connected to the stakes?
+8. **Strengths**: What works well and should be preserved?
+9. **Suggestions**: Specific, actionable improvements with brief examples where helpful.
+
+Be honest but constructive. Lead with what works well, then address what can be improved.`,
+
+    chapter_editor: `You are an expert fiction editor. Your job is to rewrite and improve a chapter based on the review feedback provided.
+
+Focus on:
+1. **Prose polishing**: Improve sentence rhythm, word choice, and flow
+2. **Show vs tell**: Convert telling passages into vivid, sensory scenes
+3. **Dialogue**: Sharpen character voices and remove on-the-nose exchanges
+4. **Pacing**: Trim slow sections, expand rushed moments
+5. **Consistency**: Ensure character behaviour and lore details are accurate
+
+Preserve the author's voice and the core story beats. Return the full rewritten chapter text.`,
+
+    custom: `You are a helpful AI assistant. Follow the instructions provided and assist with the writing task.`,
+
+    lore_writer: `You are a lorebook entry creator for a fiction writing tool. Your job is to generate a single, well-structured lorebook entry from a seed concept provided by the user.
+
+Output ONLY a single JSON object wrapped in a \`\`\`json code fence — no prose, no commentary, nothing else.
+
+The JSON object must use these fields:
+- "name": string (required) — the entry's primary name
+- "category": one of "character" | "location" | "item" | "event" | "note" | "synopsis" | "starting scenario" | "timeline" (required)
+- "description": string (required) — rich, detailed description covering all relevant aspects
+- "tags": string[] — keywords for matching this entry in context (include aliases, related terms)
+- "metadata": object (optional) — may include:
+  - "type": string (e.g. "Protagonist", "Villain", "Capital City", "Weapon")
+  - "importance": "major" | "minor" | "background"
+  - "status": "active" | "inactive" | "historical"
+
+Write a description that is vivid and specific. Use the aspects the user requests or the template guidance they provide. Do not pad with generic filler.`,
+
+    lore_refiner: `You are a lorebook entry editor for a fiction writing tool. You will receive an existing lorebook entry as your prior output, and the user will give you instructions to refine it.
+
+Output ONLY the updated JSON object wrapped in a \`\`\`json code fence — no prose, no commentary, nothing else.
+
+Use the same field structure as the entry you received:
+- "name": string (required)
+- "category": one of "character" | "location" | "item" | "event" | "note" | "synopsis" | "starting scenario" | "timeline" (required)
+- "description": string (required)
+- "tags": string[]
+- "metadata": object (optional) with "type", "importance", "status"
+
+Preserve existing content that the user does not ask you to change. Apply the user's refinement instructions precisely. Return the complete updated entry, not just the changed fields.`,
+
+    judge_aggregator: `You are a judge aggregator for fiction writing. Your job is to review the outputs from multiple judge agents (lore judge, continuity checker, etc.) and produce a single clear verdict.
+
+Rules:
+- If ALL judges found no issues (each returned CONSISTENT or similar): respond with only: PASS
+- If ANY judge found issues: respond with ISSUES_FOUND on the first line, then a concise, prioritised list of the problems to fix and how to fix them.
+
+Format when issues exist:
+ISSUES_FOUND
+[Numbered list of issues, most critical first. For each: what is wrong and the suggested fix.]
+
+Be concise and actionable. Merge duplicate issues from different judges. Omit style preferences — only flag factual contradictions and continuity errors.
+Do NOT use the word "issue" outside of the ISSUES_FOUND block.`
 };
 
 interface AgentsState {
@@ -328,6 +398,11 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
             style_extractor: 'Style Extractor',
             scenebeat_generator: 'Scene Beat Generator',
             refusal_checker: 'Refusal Checker',
+            chapter_reviewer: 'Chapter Reviewer',
+            chapter_editor: 'Chapter Editor',
+            lore_writer: 'Lore Writer',
+            lore_refiner: 'Lore Refiner',
+            judge_aggregator: 'Judge Aggregator',
             custom: 'Custom Agent'
         };
 

--- a/src/features/scenebeats/hooks/useSceneBeatGeneration.ts
+++ b/src/features/scenebeats/hooks/useSceneBeatGeneration.ts
@@ -384,15 +384,42 @@ export function useSceneBeatGeneration(store: SceneBeatInstanceStoreApi) {
                     store.setState((prev) => ({
                         agenticStepResults: [...prev.agenticStepResults, stepResult],
                     }));
+                    // Surface judge feedback inline (Area 4)
+                    const isJudge = stepResult.role === 'lore_judge' || stepResult.role === 'continuity_checker' ||
+                        stepResult.role === 'judge_aggregator';
+                    if (isJudge) {
+                        const upper = stepResult.output.toUpperCase().trim();
+                        const hasSentinel = upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##');
+                        const hasAggregatorIssues = upper.startsWith('ISSUES_FOUND');
+                        const isConsistent = upper.startsWith('CONSISTENT') || upper.startsWith('PASS');
+                        const hasLegacyIssue = !isConsistent && upper.includes('ISSUE') &&
+                            !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
+                        const hasIssues = hasSentinel || hasAggregatorIssues || hasLegacyIssue;
+                        store.setState((prev) => ({
+                            agenticJudgeResults: [...prev.agenticJudgeResults, stepResult],
+                            latestJudgeFeedback: hasIssues ? stepResult.output : null,
+                            showJudgeFeedback: hasIssues,
+                        }));
+                    }
                 },
                 onToken: (token) => store.getState().appendStreamedText(token),
                 onComplete: (pipelineResult) => {
                     console.log('[Agentic] Pipeline complete:', pipelineResult);
-                    store.setState({ streamComplete: true, showAgenticProgress: false });
-                    updateNodeSnapshot({
-                        generatedContent: store.getState().streamedText,
-                        accepted: false,
-                    });
+                    store.setState({ streaming: false, streamComplete: true, showAgenticProgress: false });
+
+                    // Completion toast (Area 5)
+                    const pipelineName = s.selectedPipeline?.name || 'Pipeline';
+                    const stepCount = pipelineResult.steps.length;
+                    if (pipelineResult.loopLimitReached) {
+                        toast.warn(
+                            `${pipelineName} — revision loop limit reached. Output provided but issues may remain. Check diagnostics for details.`,
+                            { autoClose: 8000 }
+                        );
+                    } else if (pipelineResult.verificationStatus === 'failed') {
+                        toast.warn(`${pipelineName} complete — issues remain (${stepCount} steps)`, { autoClose: 5000 });
+                    } else {
+                        toast.success(`${pipelineName} complete (${stepCount} steps)`, { autoClose: 3000 });
+                    }
 
                     if (s.sceneBeatId) {
                         sceneBeatService.updateSceneBeat(s.sceneBeatId, {

--- a/src/lib/thinking.ts
+++ b/src/lib/thinking.ts
@@ -1,0 +1,52 @@
+/**
+ * Utilities for handling <think>...</think> blocks emitted by reasoning models.
+ * The thinking content is separated so it can be displayed independently from
+ * the prose output.
+ */
+
+export interface ThinkingSplit {
+    /** The model's internal reasoning text (content of <think> blocks). */
+    thinkingText: string;
+    /** The actual prose output, with all <think> blocks removed. */
+    proseText: string;
+}
+
+/**
+ * Split raw model output that may contain `<think>...</think>` blocks.
+ *
+ * Handles:
+ * - Multiple complete `<think>...</think>` blocks
+ * - An unclosed `<think>` block that is still streaming
+ */
+export function splitThinkingContent(raw: string): ThinkingSplit {
+    const thinkParts: string[] = [];
+
+    // Extract complete <think>...</think> blocks (case-insensitive, greedy-safe)
+    let prose = raw.replace(/<think>([\s\S]*?)<\/think>/gi, (_, content: string) => {
+        thinkParts.push(content.trim());
+        return '';
+    });
+
+    // Handle an incomplete open <think> block still being streamed
+    const openIdx = prose.search(/<think>/i);
+    if (openIdx !== -1) {
+        const innerContent = prose.slice(openIdx + '<think>'.length);
+        thinkParts.push(innerContent);
+        prose = prose.slice(0, openIdx);
+    }
+
+    // Handle orphan </think>: some models (via LMStudio) suppress the opening <think> token
+    // but emit </think> as plain text. Everything before </think> is thinking content.
+    if (thinkParts.length === 0) {
+        const closeIdx = prose.search(/<\/think>/i);
+        if (closeIdx !== -1) {
+            thinkParts.push(prose.slice(0, closeIdx).trim());
+            prose = prose.slice(closeIdx + '</think>'.length);
+        }
+    }
+
+    return {
+        proseText: prose.trimStart(),
+        thinkingText: thinkParts.join('\n\n').trim(),
+    };
+}

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -268,7 +268,7 @@ export class AgentOrchestrator {
      * This is the actual content the user wants, not judge/checker outputs
      */
     private getLastProseOutput(results: AgentResult[]): string {
-        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor', 'chapter_reviewer'];
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
 
         // Find the last result from a prose-generating role
         for (let i = results.length - 1; i >= 0; i--) {
@@ -285,7 +285,7 @@ export class AgentOrchestrator {
      * Always scans backwards so revision loops return the most recent prose, not the first.
      */
     private getLastProseResult(results: AgentResult[]): AgentResult | undefined {
-        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor', 'chapter_reviewer'];
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
         for (let i = results.length - 1; i >= 0; i--) {
             if (proseRoles.includes(results[i].role)) {
                 return results[i];
@@ -327,8 +327,9 @@ export class AgentOrchestrator {
         // Push prompt mode: build multi-turn chat memory
         // [system, originalUser, assistantRefusal, pushPromptUser]
         if (isRevision && step?.pushPrompt && previousResults.length > 0) {
-            // Find the prose writer's original output (the refusal)
-            const proseResult = previousResults.find(r => r.role === 'prose_writer');
+            // Find the MOST RECENT prose writer output (last iteration, not first)
+            const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
+            const proseResult = [...previousResults].reverse().find(r => proseRoles.includes(r.role));
             const previousOutput = proseResult?.output || previousResults[previousResults.length - 1]?.output || '';
 
             // Feedback from the checker (e.g. refusal_checker or lore_judge)
@@ -476,13 +477,19 @@ export class AgentOrchestrator {
                 return this.buildContinuityCheckerMessage(agent, input, previousResults);
 
             case 'style_editor':
-                return this.buildStyleEditorMessage(agent, previousResults);
+                return isRevision
+                    ? this.buildRevisionMessage(agent, input, previousResults)
+                    : this.buildStyleEditorMessage(agent, previousResults);
 
             case 'dialogue_specialist':
-                return this.buildDialogueSpecialistMessage(agent, previousResults);
+                return isRevision
+                    ? this.buildRevisionMessage(agent, input, previousResults)
+                    : this.buildDialogueSpecialistMessage(agent, previousResults);
 
             case 'expander':
-                return this.buildExpanderMessage(agent, input, previousResults);
+                return isRevision
+                    ? this.buildRevisionMessage(agent, input, previousResults)
+                    : this.buildExpanderMessage(agent, input, previousResults);
 
             case 'outline_generator':
                 return this.buildOutlineGeneratorMessage(agent, input, previousResults);
@@ -565,9 +572,16 @@ export class AgentOrchestrator {
         const proseResults = previousResults.filter(r => r.role === 'prose_writer');
         const originalProse = proseResults[proseResults.length - 1]?.output || '';
 
-        // Find feedback from judges (lore_judge or continuity_checker)
-        const feedbackResults = previousResults.filter(r => 
-            r.role === 'lore_judge' || r.role === 'continuity_checker'
+        // Find feedback from judges that came AFTER the last prose output only.
+        // This prevents stacking feedback from earlier iterations when maxIterations > 1.
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
+        const lastProseIdx = previousResults.reduce(
+            (last, r, idx) => proseRoles.includes(r.role) ? idx : last,
+            -1
+        );
+        const feedbackResults = previousResults.filter((r, idx) =>
+            idx > lastProseIdx &&
+            (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
         );
         const feedback = feedbackResults
             .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)
@@ -735,19 +749,20 @@ Provide the improved version:`;
         const lorebookEntries = this.getLorebookForAgent(agent, input);
         const MAX_LORE_DESC_CHARS = 300;
 
-        // Find the last chapter_editor output as the prose to revise
-        const lastEditorIdx = previousResults.reduce(
-            (last, r, idx) => r.role === 'chapter_editor' ? idx : last,
+        // Find the last prose output from any prose-producing role
+        const allProseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
+        const lastProseIdx = previousResults.reduce(
+            (last, r, idx) => allProseRoles.includes(r.role) ? idx : last,
             -1,
         );
-        const originalProse = lastEditorIdx >= 0
-            ? previousResults[lastEditorIdx].output
+        const originalProse = lastProseIdx >= 0
+            ? previousResults[lastProseIdx].output
             : input.previousWords || '';
 
-        // Collect reviewer/judge feedback from steps after the last chapter_editor output
+        // Collect reviewer/judge feedback from steps after the last prose output
         const feedbackRoles: AgentRole[] = ['chapter_reviewer', 'lore_judge', 'continuity_checker'];
         const feedbackResults = previousResults.filter(
-            (r, idx) => idx > lastEditorIdx && feedbackRoles.includes(r.role),
+            (r, idx) => idx > lastProseIdx && feedbackRoles.includes(r.role),
         );
         const feedback = feedbackResults
             .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -1,4 +1,5 @@
 import { aiService } from './AIService';
+import { splitThinkingContent } from '@/lib/thinking';
 import {
     PromptMessage,
     AllowedModel,
@@ -57,6 +58,12 @@ export interface PipelineResult {
     totalDuration: number;
     status: 'completed' | 'failed' | 'aborted';
     error?: string;
+    // Whether the final judge pass confirmed all issues were resolved
+    verificationStatus?: 'passed' | 'failed' | 'skipped';
+    // Raw output from the last judge, if issues remain
+    unresolvedIssues?: string;
+    // True when a revision loop exhausted its maxIterations while the condition was still active
+    loopLimitReached?: boolean;
 }
 
 export class AgentOrchestrator {
@@ -89,8 +96,10 @@ export class AgentOrchestrator {
         const startTime = Date.now();
         this.abortController = new AbortController();
 
-        // Track iteration counts per retry-point to enforce maxIterations
+        // Track completed iteration counts per retry-point step index to enforce maxIterations.
+        // A value of N means the revision step has already executed N times.
         const iterationCounts = new Map<number, number>();
+        let loopLimitReached = false;
 
         try {
             let i = 0;
@@ -111,27 +120,8 @@ export class AgentOrchestrator {
                 // Check condition if provided (pass step for keyword-based conditions)
                 if (step.condition && !this.evaluateCondition(step.condition, input, results, step)) {
                     console.log(`[AgentOrchestrator] Skipping step ${i} (${step.agent.name}): condition not met`);
-
                     i++;
                     continue;
-                }
-
-                // Handle retry loop: if this step has retryFromStep and its condition passed,
-                // we need to check if we should jump back
-                if (step.retryFromStep !== undefined && step.retryFromStep !== null && step.condition) {
-                    const maxIter = step.maxIterations ?? 1;
-                    const currentIter = iterationCounts.get(i) ?? 0;
-
-                    if (currentIter < maxIter) {
-                        iterationCounts.set(i, currentIter + 1);
-                        console.log(`[AgentOrchestrator] Retry loop: jumping from step ${i} back to step ${step.retryFromStep} (iteration ${currentIter + 1}/${maxIter})`);
-                        i = step.retryFromStep;
-                        continue; // Re-run from retryFromStep
-                    } else {
-                        console.log(`[AgentOrchestrator] Retry loop: max iterations (${maxIter}) reached at step ${i}, skipping`);
-                        i++;
-                        continue;
-                    }
                 }
 
                 callbacks?.onStepStart?.(step, i);
@@ -141,16 +131,25 @@ export class AgentOrchestrator {
                     const messages = this.buildMessages(step.agent, input, results, step.isRevision, step);
                     const shouldStream = step.streamOutput ?? false; // Default to NOT streaming
 
-                    let output: string;
+                    let rawOutput: string;
                     if (shouldStream && callbacks?.onToken) {
-                        output = await this.generateStreaming(step.agent, messages, callbacks.onToken);
+                        rawOutput = await this.generateStreaming(step.agent, messages, callbacks.onToken);
                     } else {
-                        output = await this.generateNonStreaming(step.agent, messages);
+                        rawOutput = await this.generateNonStreaming(step.agent, messages);
                     }
+
+                    // Strip <think>...</think> blocks from ALL step outputs so that judge feedback
+                    // and prose passed between steps is never contaminated by reasoning tokens.
+                    // The thinking text is preserved in metadata for diagnostics.
+                    const { proseText: output, thinkingText } = splitThinkingContent(rawOutput);
+
+                    const completedIter = (iterationCounts.get(i) ?? 0) + 1;
+                    iterationCounts.set(i, completedIter);
 
                     const metadata: Record<string, unknown> = {};
                     if (step.isRevision) metadata.isRevision = true;
-                    if (iterationCounts.has(i)) metadata.iteration = iterationCounts.get(i);
+                    metadata.iteration = completedIter;
+                    if (thinkingText) metadata.thinkingText = thinkingText;
 
                     const result: AgentResult = {
                         role: step.agent.role,
@@ -163,6 +162,22 @@ export class AgentOrchestrator {
 
                     results.push(result);
                     callbacks?.onStepComplete?.(result, i);
+
+                    // Retry loop (evaluated AFTER execution so the step always runs at least once
+                    // when its condition is met). retryFromStep points to an earlier step index
+                    // that begins the next iteration (e.g. the lore_judge that should re-check
+                    // the revised prose).
+                    if (step.retryFromStep !== undefined && step.retryFromStep !== null && step.condition) {
+                        const maxIter = step.maxIterations ?? 1;
+                        if (completedIter < maxIter) {
+                            console.log(`[AgentOrchestrator] Retry loop: jumping from step ${i} back to step ${step.retryFromStep} (iteration ${completedIter}/${maxIter})`);
+                            i = step.retryFromStep;
+                            continue; // Re-run from retryFromStep
+                        } else {
+                            console.log(`[AgentOrchestrator] Retry loop: max iterations (${maxIter}) reached at step ${i}`);
+                            loopLimitReached = true;
+                        }
+                    }
 
                 } catch (error) {
                     console.error(`[AgentOrchestrator] Error in step ${i}:`, error);
@@ -193,12 +208,30 @@ export class AgentOrchestrator {
             // Find the prose output (last prose_writer, style_editor, or dialogue_specialist)
             const proseOutput = this.getLastProseOutput(results);
 
+            // Determine verification status from the last judge/aggregator result
+            const lastJudgeResult = [...results].reverse().find(r =>
+                r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'judge_aggregator'
+            );
+            let verificationStatus: PipelineResult['verificationStatus'] = 'skipped';
+            let unresolvedIssues: string | undefined;
+            if (lastJudgeResult) {
+                if (this.hasJudgeIssues(lastJudgeResult.output)) {
+                    verificationStatus = 'failed';
+                    unresolvedIssues = lastJudgeResult.output;
+                } else {
+                    verificationStatus = 'passed';
+                }
+            }
+
             return {
                 finalOutput: results[results.length - 1]?.output ?? '',
                 proseOutput,
                 steps: results,
                 totalDuration: Date.now() - startTime,
-                status: 'completed'
+                status: 'completed',
+                verificationStatus,
+                unresolvedIssues,
+                loopLimitReached: loopLimitReached || undefined,
             };
 
         } catch (error) {
@@ -296,15 +329,19 @@ export class AgentOrchestrator {
 
     /**
      * Determine whether a judge/checker output contains reported issues.
-     * Handles both the new sentinel token format (##LORE_ISSUE##, ##CONTINUITY_ISSUE##)
-     * and the legacy free-text "ISSUE:" format for backward compatibility with existing presets.
+     * Handles sentinel token formats from all judge roles:
+     *   - ##LORE_ISSUE##, ##CONTINUITY_ISSUE## (lore_judge / continuity_checker)
+     *   - ISSUES_FOUND (judge_aggregator)
+     *   - Legacy free-text "ISSUE:" format for backward compatibility.
      */
     private hasJudgeIssues(output: string): boolean {
-        const upper = output.toUpperCase();
+        const upper = output.toUpperCase().trim();
         // New sentinel tokens — unambiguous
         if (upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##')) return true;
-        // If the output starts with CONSISTENT it is clean — check this before legacy scan
-        if (upper.trimStart().startsWith('CONSISTENT')) return false;
+        // Judge aggregator sentinel
+        if (upper.startsWith('ISSUES_FOUND')) return true;
+        // Clean-state markers — check before legacy scan
+        if (upper.startsWith('CONSISTENT') || upper.startsWith('PASS')) return false;
         // Legacy: bare ISSUE keyword but not negated
         return upper.includes('ISSUE') && !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
     }
@@ -508,6 +545,9 @@ export class AgentOrchestrator {
                     ? this.buildChapterEditorRevisionMessage(agent, input, previousResults)
                     : this.buildChapterEditorMessage(agent, input);
 
+            case 'judge_aggregator':
+                return this.buildJudgeAggregatorMessage(previousResults);
+
             case 'custom':
             default:
                 return this.buildCustomMessage(agent, input, previousResults);
@@ -579,13 +619,25 @@ export class AgentOrchestrator {
             (last, r, idx) => proseRoles.includes(r.role) ? idx : last,
             -1
         );
-        const feedbackResults = previousResults.filter((r, idx) =>
-            idx > lastProseIdx &&
-            (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
-        );
-        const feedback = feedbackResults
-            .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)
-            .join('\n\n');
+
+        // Prefer judge_aggregator synthesis (cleaner, de-duplicated feedback) when present.
+        // Fall back to raw judge outputs if no aggregator ran.
+        const aggregatorResult = [...previousResults].slice(lastProseIdx + 1)
+            .reverse()
+            .find(r => r.role === 'judge_aggregator');
+
+        let feedback: string;
+        if (aggregatorResult) {
+            feedback = `[JUDGE AGGREGATOR FEEDBACK]:\n${aggregatorResult.output}`;
+        } else {
+            const feedbackResults = previousResults.filter((r, idx) =>
+                idx > lastProseIdx &&
+                (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
+            );
+            feedback = feedbackResults
+                .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)
+                .join('\n\n');
+        }
 
         // Build lorebook context for reference (full descriptions)
         const lorebookContext = lorebookEntries
@@ -638,6 +690,38 @@ NEW PROSE:
 ${proseOutput}
 
 List any continuity issues (timeline inconsistencies, character behavior changes, forgotten plot points). If consistent, respond with: CONSISTENT`;
+    }
+
+    /**
+     * Build the user message for the judge_aggregator role.
+     * Collects all judge/checker outputs since the last prose step and formats them
+     * so the aggregator can synthesise a single PASS or ISSUES_FOUND decision.
+     */
+    private buildJudgeAggregatorMessage(previousResults: AgentResult[]): string {
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
+        const lastProseIdx = previousResults.reduce(
+            (last, r, idx) => proseRoles.includes(r.role) ? idx : last,
+            -1
+        );
+
+        const judgeResults = previousResults.filter((r, idx) =>
+            idx > lastProseIdx &&
+            (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
+        );
+
+        if (judgeResults.length === 0) {
+            return 'No judge outputs are available to review. Respond with: PASS';
+        }
+
+        const judgeOutputs = judgeResults
+            .map(r => `[${r.agentName.toUpperCase()}]:\n${r.output}`)
+            .join('\n\n---\n\n');
+
+        return `Review the following judge outputs and determine whether the prose has any issues that need to be addressed.
+
+${judgeOutputs}
+
+Provide your assessment.`;
     }
 
     private buildStyleEditorMessage(agent: AgentPreset, previousResults: AgentResult[]): string {
@@ -1007,6 +1091,15 @@ Provide the improved version:`;
                     const searchText = parts.slice(1).join(':').trim();
                     const roleResult = previousResults.find(r => r.role.toLowerCase() === role);
                     if (roleResult) {
+                        // When checking raw judge roles for "ISSUE", use the robust hasJudgeIssues helper.
+                        // judge_aggregator uses ISSUES_FOUND (not ISSUE), so let it use plain text matching.
+                        const isRawJudgeRole = role !== 'judge_aggregator' && (
+                            role === 'lore_judge' || role === 'continuity_checker' ||
+                            role.includes('judge') || role.includes('checker')
+                        );
+                        if (isRawJudgeRole && searchText.toUpperCase() === 'ISSUE') {
+                            return this.hasJudgeIssues(roleResult.output);
+                        }
                         return roleResult.output.toUpperCase().includes(searchText.toUpperCase());
                     }
                     return false;
@@ -1020,23 +1113,16 @@ Provide the improved version:`;
                 return !lastOutput.toUpperCase().includes(searchText.toUpperCase());
             }
 
-            // Check if ANY judge role found issues (lore_judge, continuity_checker, or any role with 'judge' or 'checker')
+            // Check if ANY judge role found issues (lore_judge, continuity_checker, or any role with 'judge' or 'checker').
+            // judge_aggregator is excluded here — use roleOutputContains:judge_aggregator:ISSUES_FOUND instead.
             if (normalizedCondition === 'anyjudgefoundissues') {
                 const judgeRoles = ['lore_judge', 'continuity_checker'];
                 return previousResults.some(r => {
-                    const isJudgeRole = judgeRoles.includes(r.role) || 
-                                       r.role.includes('judge') || 
-                                       r.role.includes('checker');
-                    if (isJudgeRole) {
-                        // Check for common issue markers
-                        const output = r.output.toUpperCase();
-                        return output.includes('ISSUE') || 
-                               output.includes('INCONSISTEN') || 
-                               output.includes('ERROR') ||
-                               output.includes('PROBLEM') ||
-                               output.includes('CONFLICT');
-                    }
-                    return false;
+                    const isJudgeRole = r.role !== 'judge_aggregator' && (
+                        r.role === 'lore_judge' || r.role === 'continuity_checker' ||
+                        r.role.includes('judge') || r.role.includes('checker')
+                    );
+                    return isJudgeRole && this.hasJudgeIssues(r.output);
                 });
             }
 
@@ -1098,11 +1184,14 @@ Provide the improved version:`;
             previousOutput = previousResults[previousResults.length - 1].output;
         }
 
-        // Collect feedback from judge/checker roles
-        const feedbackResults = previousResults.filter(r =>
-            r.role === 'lore_judge' || r.role === 'continuity_checker' ||
-            r.role.includes('judge') || r.role.includes('checker')
-        );
+        // Collect feedback from judge/checker roles (prefer aggregator if present)
+        const aggregator = [...previousResults].reverse().find(r => r.role === 'judge_aggregator');
+        const feedbackResults = aggregator
+            ? [aggregator]
+            : previousResults.filter(r =>
+                r.role === 'lore_judge' || r.role === 'continuity_checker' ||
+                (r.role !== 'judge_aggregator' && (r.role.includes('judge') || r.role.includes('checker')))
+            );
         const feedback = feedbackResults.length > 0
             ? feedbackResults.map(r => `[${r.agentName}]:\n${r.output}`).join('\n\n')
             : 'No specific feedback available.';

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -268,8 +268,8 @@ export class AgentOrchestrator {
      * This is the actual content the user wants, not judge/checker outputs
      */
     private getLastProseOutput(results: AgentResult[]): string {
-        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander'];
-        
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor', 'chapter_reviewer'];
+
         // Find the last result from a prose-generating role
         for (let i = results.length - 1; i >= 0; i--) {
             if (proseRoles.includes(results[i].role)) {
@@ -278,6 +278,35 @@ export class AgentOrchestrator {
         }
         
         return '';
+    }
+
+    /**
+     * Get the last prose AgentResult (not just the output string).
+     * Always scans backwards so revision loops return the most recent prose, not the first.
+     */
+    private getLastProseResult(results: AgentResult[]): AgentResult | undefined {
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor', 'chapter_reviewer'];
+        for (let i = results.length - 1; i >= 0; i--) {
+            if (proseRoles.includes(results[i].role)) {
+                return results[i];
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Determine whether a judge/checker output contains reported issues.
+     * Handles both the new sentinel token format (##LORE_ISSUE##, ##CONTINUITY_ISSUE##)
+     * and the legacy free-text "ISSUE:" format for backward compatibility with existing presets.
+     */
+    private hasJudgeIssues(output: string): boolean {
+        const upper = output.toUpperCase();
+        // New sentinel tokens — unambiguous
+        if (upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##')) return true;
+        // If the output starts with CONSISTENT it is clean — check this before legacy scan
+        if (upper.trimStart().startsWith('CONSISTENT')) return false;
+        // Legacy: bare ISSUE keyword but not negated
+        return upper.includes('ISSUE') && !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
     }
 
     /**
@@ -464,6 +493,14 @@ export class AgentOrchestrator {
             case 'scenebeat_generator':
                 return this.buildScenebeatGeneratorMessage(agent, input, previousResults);
 
+            case 'chapter_reviewer':
+                return this.buildChapterReviewerMessage(agent, input);
+
+            case 'chapter_editor':
+                return isRevision
+                    ? this.buildChapterEditorRevisionMessage(agent, input, previousResults)
+                    : this.buildChapterEditorMessage(agent, input);
+
             case 'custom':
             default:
                 return this.buildCustomMessage(agent, input, previousResults);
@@ -642,6 +679,147 @@ Provide the improved version:`;
         }
 
         message += `Expand the following brief notes/outline into detailed prose:\n\nNOTES:\n${briefNotes}\n\nWrite a fully expanded scene:`;
+
+        return message;
+    }
+
+    private buildChapterEditorMessage(agent: AgentPreset, input: PipelineInput): string {
+        const lorebookEntries = this.getLorebookForAgent(agent, input);
+        const chapterText = input.previousWords || '';
+        const editInstructions = input.scenebeat || '';
+
+        // Cap each lorebook description to avoid token overflow when editing long chapters.
+        // The model must output the full chapter back, so we budget tightly for lore context.
+        const MAX_LORE_DESC_CHARS = 300;
+
+        let message = '';
+
+        // Include lorebook so the editor can preserve lore-accurate details
+        if (lorebookEntries.length > 0) {
+            const lorebookContext = lorebookEntries
+                .map(e => {
+                    const desc = e.description.length > MAX_LORE_DESC_CHARS
+                        ? e.description.slice(0, MAX_LORE_DESC_CHARS) + '…'
+                        : e.description;
+                    return `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${desc}`;
+                })
+                .join('\n\n');
+            message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
+        }
+
+        // Add POV info so voice is preserved
+        if (input.povType) {
+            message += `POV: ${input.povType}`;
+            if (input.povCharacter) {
+                message += ` (${input.povCharacter})`;
+            }
+            message += '\n\n';
+        }
+
+        message += `CHAPTER TO EDIT:\n${chapterText}\n\n`;
+
+        if (editInstructions) {
+            message += `EDITING INSTRUCTIONS:\n${editInstructions}\n\n`;
+        }
+
+        message += `---\nReturn the complete edited chapter text and nothing else:`;
+
+        return message;
+    }
+
+    private buildChapterEditorRevisionMessage(
+        agent: AgentPreset,
+        input: PipelineInput,
+        previousResults: AgentResult[],
+    ): string {
+        const lorebookEntries = this.getLorebookForAgent(agent, input);
+        const MAX_LORE_DESC_CHARS = 300;
+
+        // Find the last chapter_editor output as the prose to revise
+        const lastEditorIdx = previousResults.reduce(
+            (last, r, idx) => r.role === 'chapter_editor' ? idx : last,
+            -1,
+        );
+        const originalProse = lastEditorIdx >= 0
+            ? previousResults[lastEditorIdx].output
+            : input.previousWords || '';
+
+        // Collect reviewer/judge feedback from steps after the last chapter_editor output
+        const feedbackRoles: AgentRole[] = ['chapter_reviewer', 'lore_judge', 'continuity_checker'];
+        const feedbackResults = previousResults.filter(
+            (r, idx) => idx > lastEditorIdx && feedbackRoles.includes(r.role),
+        );
+        const feedback = feedbackResults
+            .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)
+            .join('\n\n');
+
+        let message = 'You need to REVISE the following chapter based on the feedback provided.\n\n';
+
+        if (lorebookEntries.length > 0) {
+            const lorebookContext = lorebookEntries
+                .map(e => {
+                    const desc = e.description.length > MAX_LORE_DESC_CHARS
+                        ? e.description.slice(0, MAX_LORE_DESC_CHARS) + '…'
+                        : e.description;
+                    return `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${desc}`;
+                })
+                .join('\n\n');
+            message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
+        }
+
+        if (input.povType) {
+            message += `POV: ${input.povType}`;
+            if (input.povCharacter) message += ` (${input.povCharacter})`;
+            message += '\n\n';
+        }
+
+        message += `CHAPTER TO REVISE:\n${originalProse}\n\n`;
+        message += `---\n${feedback}\n\n`;
+        message += `---\nPlease rewrite the complete chapter, addressing ALL issues from the feedback while maintaining the original intent and style. Return the full revised chapter text and nothing else:`;
+
+        return message;
+    }
+
+    private buildChapterReviewerMessage(agent: AgentPreset, input: PipelineInput): string {
+        const lorebookEntries = this.getLorebookForAgent(agent, input);
+        const chapterText = input.previousWords || '';
+        const reviewFocus = input.scenebeat || '';
+
+        const MAX_LORE_DESC_CHARS = 300;
+
+        let message = '';
+
+        // Add lorebook context so the reviewer can check for lore consistency
+        if (lorebookEntries.length > 0) {
+            const lorebookContext = lorebookEntries
+                .map(e => {
+                    const desc = e.description.length > MAX_LORE_DESC_CHARS
+                        ? e.description.slice(0, MAX_LORE_DESC_CHARS) + '…'
+                        : e.description;
+                    return `[${e.category?.toUpperCase() ?? 'LORE'}] ${e.name}: ${desc}`;
+                })
+                .join('\n\n');
+            message += `ESTABLISHED LORE & CHARACTERS:\n${lorebookContext}\n\n`;
+        }
+
+        // Add POV info if available
+        if (input.povType) {
+            message += `POV: ${input.povType}`;
+            if (input.povCharacter) {
+                message += ` (${input.povCharacter})`;
+            }
+            message += '\n\n';
+        }
+
+        // Add the chapter text to review
+        message += `CHAPTER TEXT TO REVIEW:\n${chapterText}\n\n`;
+
+        // Add optional reviewer focus/instructions
+        if (reviewFocus) {
+            message += `REVIEW FOCUS:\n${reviewFocus}\n\n`;
+        }
+
+        message += `---\nPlease provide a detailed review of the chapter above.`;
 
         return message;
     }

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -388,6 +388,11 @@ export type AgentRole =
   | "style_extractor" // Extracts writing style from sample text
   | "scenebeat_generator" // Generates scene beat commands
   | "refusal_checker" // Detects if the LLM refused to generate content
+  | "chapter_reviewer" // Reviews an entire chapter for quality, consistency, and suggestions
+  | "chapter_editor" // Rewrites/edits an entire chapter based on instructions
+  | "lore_writer" // Creates new lorebook entries from a seed concept
+  | "lore_refiner" // Iteratively refines existing lorebook entries
+  | "judge_aggregator" // Synthesises outputs from all judges since the last prose step
   | "custom"; // User-defined agent role
 
 // Context configuration for agents - controls what data is sent to the LLM
@@ -485,6 +490,36 @@ export const DEFAULT_CONTEXT_CONFIG: Record<AgentRole, AgentContextConfig> = {
     includePovInfo: true,
   },
   refusal_checker: {
+    lorebookMode: "none",
+    previousWordsMode: "none",
+    includeChapterSummary: false,
+    includePovInfo: false,
+  },
+  chapter_reviewer: {
+    lorebookMode: "all",
+    previousWordsMode: "full",
+    includeChapterSummary: false,
+    includePovInfo: true,
+  },
+  chapter_editor: {
+    lorebookMode: "all",
+    previousWordsMode: "full",
+    includeChapterSummary: false,
+    includePovInfo: true,
+  },
+  lore_writer: {
+    lorebookMode: "none",
+    previousWordsMode: "none",
+    includeChapterSummary: false,
+    includePovInfo: false,
+  },
+  lore_refiner: {
+    lorebookMode: "none",
+    previousWordsMode: "none",
+    includeChapterSummary: false,
+    includePovInfo: false,
+  },
+  judge_aggregator: {
     lorebookMode: "none",
     previousWordsMode: "none",
     includeChapterSummary: false,


### PR DESCRIPTION
## Summary

- Adds a `judge_aggregator` pipeline role that synthesises outputs from all judges since the last prose step into a single `PASS` or `ISSUES_FOUND` verdict, providing cleaner revision feedback
- Fixes a bug where the `retryFromStep` jump happened *before* the LLM executed — revision steps with a retry loop never actually generated prose; the jump is now evaluated after execution so the step always runs at least once when its condition is met (`maxIterations=N` executes exactly N times)
- Adds `chapter_editor` and `chapter_reviewer` agent roles with full pipeline support, including dedicated `buildChapterEditorMessage`, `buildChapterEditorRevisionMessage`, and `buildChapterReviewerMessage` methods in `AgentOrchestrator`
- Extends revision routing (`buildRevisionMessage`) to all prose-producing roles (`style_editor`, `dialogue_specialist`, `expander`, `chapter_editor`) — not just `prose_writer`
- Fixes feedback collection in revision steps to only gather judge results *after* the last prose output, preventing stale feedback stacking across iterations
- Adds `loopLimitReached` and `verificationStatus` fields to `PipelineResult` for surfacing pipeline outcomes as toasts
- Improves `continuity_checker` prompt with sentinel token format (`##CONTINUITY_ISSUE##`) and fine-grained in-scene detail drift checks (clothing, jewellery, wounds, object positions)
- Adds seeded pipeline presets: "Quality Prose with Verification" and "Quality Prose with Judge Loop"
- Adds `src/lib/thinking.ts` utility to strip `<think>…</think>` reasoning tokens from model output so judge feedback and prose passed between steps is never contaminated

## Test plan

- [ ] Create a pipeline with `prose_writer → lore_judge → prose_writer (isRevision, retryFromStep)` and confirm the revision step executes prose on each iteration
- [ ] Create a pipeline with `judge_aggregator` and verify it synthesises lore_judge + continuity_checker outputs into a single PASS/ISSUES_FOUND verdict
- [ ] Confirm `roleOutputContains:judge_aggregator:ISSUES_FOUND` condition triggers correctly
- [ ] Confirm `loopLimitReached` toast appears when max iterations are exhausted with issues remaining
- [ ] Add a `chapter_editor` and `chapter_reviewer` agent preset and confirm they appear in the pipeline builder with the correct role colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)